### PR TITLE
update for 2022.10 spec

### DIFF
--- a/src/main/java/com/synopsys/integration/blackduck/api/generated/component/BomStatusScanView.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/generated/component/BomStatusScanView.java
@@ -1,0 +1,25 @@
+/*
+ * blackduck-common-api
+ *
+ * Copyright (c) 2022 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
+package com.synopsys.integration.blackduck.api.generated.component;
+
+import com.synopsys.integration.blackduck.api.core.BlackDuckComponent;
+import com.synopsys.integration.blackduck.api.generated.enumeration.BomStatusScanStatusType;
+
+// this file should not be edited - if changes are necessary, the generator should be updated, then this file should be re-created
+public class BomStatusScanView extends BlackDuckComponent {
+    private BomStatusScanStatusType status;
+
+    public BomStatusScanStatusType getStatus() {
+        return status;
+    }
+
+    public void setStatus(BomStatusScanStatusType status) {
+        this.status = status;
+    }
+
+}

--- a/src/main/java/com/synopsys/integration/blackduck/api/generated/component/ComponentSbomFieldsItemsValueView.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/generated/component/ComponentSbomFieldsItemsValueView.java
@@ -1,0 +1,43 @@
+/*
+ * blackduck-common-api
+ *
+ * Copyright (c) 2022 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
+package com.synopsys.integration.blackduck.api.generated.component;
+
+import com.synopsys.integration.blackduck.api.core.BlackDuckComponent;
+import com.synopsys.integration.blackduck.api.generated.enumeration.ComponentSbomFieldsItemsValueType;
+
+// this file should not be edited - if changes are necessary, the generator should be updated, then this file should be re-created
+public class ComponentSbomFieldsItemsValueView extends BlackDuckComponent {
+    private String email;
+    private String name;
+    private ComponentSbomFieldsItemsValueType type;
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public ComponentSbomFieldsItemsValueType getType() {
+        return type;
+    }
+
+    public void setType(ComponentSbomFieldsItemsValueType type) {
+        this.type = type;
+    }
+
+}

--- a/src/main/java/com/synopsys/integration/blackduck/api/generated/component/ComponentSbomFieldsView.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/generated/component/ComponentSbomFieldsView.java
@@ -1,0 +1,43 @@
+/*
+ * blackduck-common-api
+ *
+ * Copyright (c) 2022 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
+package com.synopsys.integration.blackduck.api.generated.component;
+
+import com.synopsys.integration.blackduck.api.core.BlackDuckComponent;
+import com.synopsys.integration.blackduck.api.generated.component.ComponentSbomFieldsItemsValueView;
+
+// this file should not be edited - if changes are necessary, the generator should be updated, then this file should be re-created
+public class ComponentSbomFieldsView extends BlackDuckComponent {
+    private String fieldName;
+    private String label;
+    private ComponentSbomFieldsItemsValueView value;
+
+    public String getFieldName() {
+        return fieldName;
+    }
+
+    public void setFieldName(String fieldName) {
+        this.fieldName = fieldName;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public void setLabel(String label) {
+        this.label = label;
+    }
+
+    public ComponentSbomFieldsItemsValueView getValue() {
+        return value;
+    }
+
+    public void setValue(ComponentSbomFieldsItemsValueView value) {
+        this.value = value;
+    }
+
+}

--- a/src/main/java/com/synopsys/integration/blackduck/api/generated/component/NotificationSubscriptionsSubscriptionView.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/generated/component/NotificationSubscriptionsSubscriptionView.java
@@ -12,6 +12,7 @@ import com.synopsys.integration.blackduck.api.core.BlackDuckComponent;
 // this file should not be edited - if changes are necessary, the generator should be updated, then this file should be re-created
 public class NotificationSubscriptionsSubscriptionView extends BlackDuckComponent {
     private java.util.Date createdAt;
+    private Boolean notifyUser;
     private String subscriptionTarget;
     private String subscriptionTargetProjectName;
     private String subscriptionTargetReleaseName;
@@ -22,6 +23,14 @@ public class NotificationSubscriptionsSubscriptionView extends BlackDuckComponen
 
     public void setCreatedAt(java.util.Date createdAt) {
         this.createdAt = createdAt;
+    }
+
+    public Boolean getNotifyUser() {
+        return notifyUser;
+    }
+
+    public void setNotifyUser(Boolean notifyUser) {
+        this.notifyUser = notifyUser;
     }
 
     public String getSubscriptionTarget() {

--- a/src/main/java/com/synopsys/integration/blackduck/api/generated/component/ScanFullResultView.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/generated/component/ScanFullResultView.java
@@ -7,6 +7,7 @@
  */
 package com.synopsys.integration.blackduck.api.generated.component;
 
+import java.math.BigDecimal;
 import com.synopsys.integration.blackduck.api.core.BlackDuckComponent;
 import com.synopsys.integration.blackduck.api.generated.component.ScanFullResultItemsAllLicensesView;
 import com.synopsys.integration.blackduck.api.generated.component.ScanFullResultItemsAllVulnerabilitiesView;
@@ -30,7 +31,9 @@ public class ScanFullResultView extends BlackDuckComponent {
     private java.util.List<java.util.List<String>> dependencyTrees;
     private String externalId;
     private java.util.List<ScanFullResultItemsFailedEvaluationPoliciesView> failedEvaluationPolicies;
+    private String filePath;
     private ScanFullResultItemsLongTermUpgradeGuidanceView longTermUpgradeGuidance;
+    private BigDecimal matchConfidence;
     private java.util.List<String> nonEvaluatedPolicies;
     private java.util.List<ScanFullResultItemsOverriddenPoliciesView> overriddenPolicies;
     private java.util.List<ScanFullResultItemsOverriddenPoliciesPartialView> overriddenPoliciesPartial;
@@ -105,12 +108,28 @@ public class ScanFullResultView extends BlackDuckComponent {
         this.failedEvaluationPolicies = failedEvaluationPolicies;
     }
 
+    public String getFilePath() {
+        return filePath;
+    }
+
+    public void setFilePath(String filePath) {
+        this.filePath = filePath;
+    }
+
     public ScanFullResultItemsLongTermUpgradeGuidanceView getLongTermUpgradeGuidance() {
         return longTermUpgradeGuidance;
     }
 
     public void setLongTermUpgradeGuidance(ScanFullResultItemsLongTermUpgradeGuidanceView longTermUpgradeGuidance) {
         this.longTermUpgradeGuidance = longTermUpgradeGuidance;
+    }
+
+    public BigDecimal getMatchConfidence() {
+        return matchConfidence;
+    }
+
+    public void setMatchConfidence(BigDecimal matchConfidence) {
+        this.matchConfidence = matchConfidence;
     }
 
     public java.util.List<String> getNonEvaluatedPolicies() {

--- a/src/main/java/com/synopsys/integration/blackduck/api/generated/component/ScopeFieldsView.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/generated/component/ScopeFieldsView.java
@@ -1,0 +1,51 @@
+/*
+ * blackduck-common-api
+ *
+ * Copyright (c) 2022 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
+package com.synopsys.integration.blackduck.api.generated.component;
+
+import com.synopsys.integration.blackduck.api.core.BlackDuckComponent;
+
+// this file should not be edited - if changes are necessary, the generator should be updated, then this file should be re-created
+public class ScopeFieldsView extends BlackDuckComponent {
+    private Boolean active;
+    private String fieldName;
+    private String label;
+    private java.util.List<String> reportType;
+
+    public Boolean getActive() {
+        return active;
+    }
+
+    public void setActive(Boolean active) {
+        this.active = active;
+    }
+
+    public String getFieldName() {
+        return fieldName;
+    }
+
+    public void setFieldName(String fieldName) {
+        this.fieldName = fieldName;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public void setLabel(String label) {
+        this.label = label;
+    }
+
+    public java.util.List<String> getReportType() {
+        return reportType;
+    }
+
+    public void setReportType(java.util.List<String> reportType) {
+        this.reportType = reportType;
+    }
+
+}

--- a/src/main/java/com/synopsys/integration/blackduck/api/generated/deprecated/component/NotificationSubscriptionView.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/generated/deprecated/component/NotificationSubscriptionView.java
@@ -14,6 +14,7 @@ import com.synopsys.integration.blackduck.api.core.BlackDuckComponent;
 @Deprecated
 public class NotificationSubscriptionView extends BlackDuckComponent {
     private java.util.Date createdAt;
+    private Boolean notifyUser;
     private String subscriptionTarget;
     private String subscriptionTargetProjectName;
     private String subscriptionTargetReleaseName;
@@ -24,6 +25,14 @@ public class NotificationSubscriptionView extends BlackDuckComponent {
 
     public void setCreatedAt(java.util.Date createdAt) {
         this.createdAt = createdAt;
+    }
+
+    public Boolean getNotifyUser() {
+        return notifyUser;
+    }
+
+    public void setNotifyUser(Boolean notifyUser) {
+        this.notifyUser = notifyUser;
     }
 
     public String getSubscriptionTarget() {

--- a/src/main/java/com/synopsys/integration/blackduck/api/generated/discovery/BlackDuckMediaTypeDiscovery.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/generated/discovery/BlackDuckMediaTypeDiscovery.java
@@ -62,6 +62,7 @@ public class BlackDuckMediaTypeDiscovery {
     public static final String API_COMPONENTS = String.format("/api/components");
     public static final String API_COMPONENTS_WITH_ID = String.format("/api/components/%s", UUID_REGEX);
     public static final String API_COMPONENTS_CUSTOM_FIELDS_WITH_ID = String.format("/api/components/%s/custom-fields/%s", UUID_REGEX, UUID_REGEX);
+    public static final String API_COMPONENTS_SBOM_FIELDS = String.format("/api/components/%s/sbom-fields", UUID_REGEX);
     public static final String API_COMPONENTS_TAGS_WITH_ID = String.format("/api/components/%s/tags/%s", UUID_REGEX, UUID_REGEX);
     public static final String API_COMPONENTS_VERSIONS_WITH_ID = String.format("/api/components/%s/versions/%s", UUID_REGEX, UUID_REGEX);
     public static final String API_COMPONENTS_VERSIONS_CUSTOM_FIELDS_WITH_ID = String.format("/api/components/%s/versions/%s/custom-fields/%s", UUID_REGEX, UUID_REGEX, UUID_REGEX);
@@ -139,6 +140,7 @@ public class BlackDuckMediaTypeDiscovery {
     public static final String API_PROJECTS_VERSIONS_WITH_ID = String.format("/api/projects/%s/versions/%s", UUID_REGEX, UUID_REGEX);
     public static final String API_PROJECTS_VERSIONS_BOM_EVENTS = String.format("/api/projects/%s/versions/%s/bom-events", UUID_REGEX, UUID_REGEX);
     public static final String API_PROJECTS_VERSIONS_BOM_STATUS = String.format("/api/projects/%s/versions/%s/bom-status", UUID_REGEX, UUID_REGEX);
+    public static final String API_PROJECTS_VERSIONS_BOM_STATUS_WITH_ID = String.format("/api/projects/%s/versions/%s/bom-status/%s", UUID_REGEX, UUID_REGEX, UUID_REGEX);
     public static final String API_PROJECTS_VERSIONS_CODE_LOCATIONS = String.format("/api/projects/%s/versions/%s/code-locations", UUID_REGEX, UUID_REGEX);
     public static final String API_PROJECTS_VERSIONS_COMPARISON = String.format("/api/projects/%s/versions/%s/comparison", UUID_REGEX, UUID_REGEX);
     public static final String API_PROJECTS_VERSIONS_COMPONENTS_WITH_ID = String.format("/api/projects/%s/versions/%s/components/%s", UUID_REGEX, UUID_REGEX, UUID_REGEX);
@@ -150,12 +152,14 @@ public class BlackDuckMediaTypeDiscovery {
     public static final String API_PROJECTS_VERSIONS_COMPONENTS_MATCHED_FILES = String.format("/api/projects/%s/versions/%s/components/%s/matched-files", UUID_REGEX, UUID_REGEX, UUID_REGEX);
     public static final String API_PROJECTS_VERSIONS_COMPONENTS_POLICY_RULES = String.format("/api/projects/%s/versions/%s/components/%s/policy-rules", UUID_REGEX, UUID_REGEX, UUID_REGEX);
     public static final String API_PROJECTS_VERSIONS_COMPONENTS_POLICY_STATUS = String.format("/api/projects/%s/versions/%s/components/%s/policy-status", UUID_REGEX, UUID_REGEX, UUID_REGEX);
+    public static final String API_PROJECTS_VERSIONS_COMPONENTS_SBOM_FIELDS = String.format("/api/projects/%s/versions/%s/components/%s/sbom-fields", UUID_REGEX, UUID_REGEX, UUID_REGEX);
     public static final String API_PROJECTS_VERSIONS_COMPONENTS_VERSIONS_WITH_ID = String.format("/api/projects/%s/versions/%s/components/%s/versions/%s", UUID_REGEX, UUID_REGEX, UUID_REGEX, UUID_REGEX);
     public static final String API_PROJECTS_VERSIONS_COMPONENTS_VERSIONS_CUSTOM_FIELDS_WITH_ID = String.format("/api/projects/%s/versions/%s/components/%s/versions/%s/custom-fields/%s", UUID_REGEX, UUID_REGEX, UUID_REGEX, UUID_REGEX, UUID_REGEX);
     public static final String API_PROJECTS_VERSIONS_COMPONENTS_VERSIONS_MATCHED_FILES = String.format("/api/projects/%s/versions/%s/components/%s/versions/%s/matched-files", UUID_REGEX, UUID_REGEX, UUID_REGEX, UUID_REGEX);
     public static final String API_PROJECTS_VERSIONS_COMPONENTS_VERSIONS_ORIGINS_MATCHED_FILES = String.format("/api/projects/%s/versions/%s/components/%s/versions/%s/origins/%s/matched-files", UUID_REGEX, UUID_REGEX, UUID_REGEX, UUID_REGEX, UUID_REGEX);
     public static final String API_PROJECTS_VERSIONS_COMPONENTS_VERSIONS_ORIGINS_VULNERABILITIES_REMEDIATION = String.format("/api/projects/%s/versions/%s/components/%s/versions/%s/origins/%s/vulnerabilities/%s/remediation", UUID_REGEX, UUID_REGEX, UUID_REGEX, UUID_REGEX, UUID_REGEX, UUID_REGEX);
     public static final String API_PROJECTS_VERSIONS_COMPONENTS_VERSIONS_POLICY_STATUS = String.format("/api/projects/%s/versions/%s/components/%s/versions/%s/policy-status", UUID_REGEX, UUID_REGEX, UUID_REGEX, UUID_REGEX);
+    public static final String API_PROJECTS_VERSIONS_COMPONENTS_VERSIONS_SBOM_FIELDS = String.format("/api/projects/%s/versions/%s/components/%s/versions/%s/sbom-fields", UUID_REGEX, UUID_REGEX, UUID_REGEX, UUID_REGEX);
     public static final String API_PROJECTS_VERSIONS_COMPONENTS_VERSIONS_VULNERABILITIES_REMEDIATION = String.format("/api/projects/%s/versions/%s/components/%s/versions/%s/vulnerabilities/%s/remediation", UUID_REGEX, UUID_REGEX, UUID_REGEX, UUID_REGEX, UUID_REGEX);
     public static final String API_PROJECTS_VERSIONS_CUSTOM_FIELDS_WITH_ID = String.format("/api/projects/%s/versions/%s/custom-fields/%s", UUID_REGEX, UUID_REGEX, UUID_REGEX);
     public static final String API_PROJECTS_VERSIONS_HIERARCHICAL_COMPONENTS = String.format("/api/projects/%s/versions/%s/hierarchical-components", UUID_REGEX, UUID_REGEX);
@@ -176,6 +180,8 @@ public class BlackDuckMediaTypeDiscovery {
     public static final String API_REGISTRATION = String.format("/api/registration");
     public static final String API_REPORTS_CONTENTS = String.format("/api/reports/%s/contents", UUID_REGEX);
     public static final String API_ROLES_WITH_ID = String.format("/api/roles/%s", UUID_REGEX);
+    public static final String API_SBOM_FIELDS_SCOPES = String.format("/api/sbom-fields/scopes");
+    public static final String API_SBOM_FIELDS_SCOPES_SCOPE_FIELDS = String.format("/api/sbom-fields/scopes/scope/fields");
     public static final String API_SCAN_READINESS = String.format("/api/scan-readiness");
     public static final String API_SCAN_SUMMARIES_WITH_ID = String.format("/api/scan-summaries/%s", UUID_REGEX);
     public static final String API_SETTINGS_ANALYSIS = String.format("/api/settings/analysis");
@@ -241,6 +247,7 @@ public class BlackDuckMediaTypeDiscovery {
         mediaTypeMatchers.add(new MediaTypeMatcher(API_CODELOCATIONS_WITH_ID, VND_BLACKDUCKSOFTWARE_SCAN_4_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_COMPONENTS, VND_BLACKDUCKSOFTWARE_COMPONENT_DETAIL_4_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_COMPONENTS_CUSTOM_FIELDS_WITH_ID, VND_BLACKDUCKSOFTWARE_COMPONENT_DETAIL_5_JSON));
+        mediaTypeMatchers.add(new MediaTypeMatcher(API_COMPONENTS_SBOM_FIELDS, VND_BLACKDUCKSOFTWARE_COMPONENT_DETAIL_5_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_COMPONENTS_TAGS_WITH_ID, VND_BLACKDUCKSOFTWARE_COMPONENT_DETAIL_5_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_COMPONENTS_VERSIONS_CUSTOM_FIELDS_WITH_ID, VND_BLACKDUCKSOFTWARE_COMPONENT_DETAIL_5_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_COMPONENTS_VERSIONS_LICENSES_TEXT, TEXT_PLAIN));
@@ -308,6 +315,7 @@ public class BlackDuckMediaTypeDiscovery {
         mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECTS_USERS_WITH_ID, VND_BLACKDUCKSOFTWARE_PROJECT_DETAIL_4_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECTS_VERSIONS_BOM_EVENTS, VND_BLACKDUCKSOFTWARE_BILL_OF_MATERIALS_6_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECTS_VERSIONS_BOM_STATUS, VND_BLACKDUCKSOFTWARE_BILL_OF_MATERIALS_6_JSON));
+        mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECTS_VERSIONS_BOM_STATUS_WITH_ID, VND_BLACKDUCKSOFTWARE_BILL_OF_MATERIALS_6_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECTS_VERSIONS_CODE_LOCATIONS, VND_BLACKDUCKSOFTWARE_INTERNAL_1_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECTS_VERSIONS_COMPARISON, VND_BLACKDUCKSOFTWARE_BILL_OF_MATERIALS_6_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECTS_VERSIONS_COMPONENTS_COMMENTS_WITH_ID, VND_BLACKDUCKSOFTWARE_BILL_OF_MATERIALS_6_JSON));
@@ -318,11 +326,13 @@ public class BlackDuckMediaTypeDiscovery {
         mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECTS_VERSIONS_COMPONENTS_MATCHED_FILES, VND_BLACKDUCKSOFTWARE_BILL_OF_MATERIALS_6_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECTS_VERSIONS_COMPONENTS_POLICY_RULES, VND_BLACKDUCKSOFTWARE_BILL_OF_MATERIALS_6_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECTS_VERSIONS_COMPONENTS_POLICY_STATUS, VND_BLACKDUCKSOFTWARE_BILL_OF_MATERIALS_6_JSON));
+        mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECTS_VERSIONS_COMPONENTS_SBOM_FIELDS, VND_BLACKDUCKSOFTWARE_BILL_OF_MATERIALS_6_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECTS_VERSIONS_COMPONENTS_VERSIONS_CUSTOM_FIELDS_WITH_ID, VND_BLACKDUCKSOFTWARE_BILL_OF_MATERIALS_6_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECTS_VERSIONS_COMPONENTS_VERSIONS_MATCHED_FILES, VND_BLACKDUCKSOFTWARE_BILL_OF_MATERIALS_6_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECTS_VERSIONS_COMPONENTS_VERSIONS_ORIGINS_MATCHED_FILES, VND_BLACKDUCKSOFTWARE_BILL_OF_MATERIALS_6_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECTS_VERSIONS_COMPONENTS_VERSIONS_ORIGINS_VULNERABILITIES_REMEDIATION, VND_BLACKDUCKSOFTWARE_BILL_OF_MATERIALS_6_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECTS_VERSIONS_COMPONENTS_VERSIONS_POLICY_STATUS, VND_BLACKDUCKSOFTWARE_BILL_OF_MATERIALS_6_JSON));
+        mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECTS_VERSIONS_COMPONENTS_VERSIONS_SBOM_FIELDS, VND_BLACKDUCKSOFTWARE_BILL_OF_MATERIALS_6_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECTS_VERSIONS_COMPONENTS_VERSIONS_VULNERABILITIES_REMEDIATION, VND_BLACKDUCKSOFTWARE_BILL_OF_MATERIALS_6_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECTS_VERSIONS_COMPONENTS_VERSIONS_WITH_ID, VND_BLACKDUCKSOFTWARE_BILL_OF_MATERIALS_6_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECTS_VERSIONS_COMPONENTS_WITH_ID, VND_BLACKDUCKSOFTWARE_BILL_OF_MATERIALS_6_JSON));
@@ -358,6 +368,8 @@ public class BlackDuckMediaTypeDiscovery {
         mediaTypeMatchers.add(new MediaTypeMatcher(API_REGISTRATION, VND_BLACKDUCKSOFTWARE_STATUS_4_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_REPORTS_CONTENTS, VND_BLACKDUCKSOFTWARE_REPORT_4_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_ROLES_WITH_ID, VND_BLACKDUCKSOFTWARE_USER_4_JSON));
+        mediaTypeMatchers.add(new MediaTypeMatcher(API_SBOM_FIELDS_SCOPES, VND_BLACKDUCKSOFTWARE_BILL_OF_MATERIALS_6_JSON));
+        mediaTypeMatchers.add(new MediaTypeMatcher(API_SBOM_FIELDS_SCOPES_SCOPE_FIELDS, VND_BLACKDUCKSOFTWARE_BILL_OF_MATERIALS_6_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_SCAN_READINESS, VND_BLACKDUCKSOFTWARE_SCAN_READINESS_1_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_SCAN_SUMMARIES_WITH_ID, VND_BLACKDUCKSOFTWARE_SCAN_6_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_SETTINGS_ANALYSIS, VND_BLACKDUCKSOFTWARE_ADMIN_4_JSON));

--- a/src/main/java/com/synopsys/integration/blackduck/api/generated/enumeration/BomStatusScanStatusType.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/generated/enumeration/BomStatusScanStatusType.java
@@ -1,0 +1,23 @@
+/*
+ * blackduck-common-api
+ *
+ * Copyright (c) 2022 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
+package com.synopsys.integration.blackduck.api.generated.enumeration;
+
+import com.synopsys.integration.util.EnumUtils;
+
+// this file should not be edited - if changes are necessary, the generator should be updated, then this file should be re-created
+public enum BomStatusScanStatusType {
+    BUILDING,
+	FAILURE,
+	NOT_INCLUDED,
+	SUCCESS;
+
+    public String prettyPrint() {
+        return EnumUtils.prettyPrint(this);
+    }
+
+}

--- a/src/main/java/com/synopsys/integration/blackduck/api/generated/enumeration/ComponentSbomFieldsItemsValueType.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/generated/enumeration/ComponentSbomFieldsItemsValueType.java
@@ -1,0 +1,21 @@
+/*
+ * blackduck-common-api
+ *
+ * Copyright (c) 2022 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
+package com.synopsys.integration.blackduck.api.generated.enumeration;
+
+import com.synopsys.integration.util.EnumUtils;
+
+// this file should not be edited - if changes are necessary, the generator should be updated, then this file should be re-created
+public enum ComponentSbomFieldsItemsValueType {
+    Organization,
+	Person;
+
+    public String prettyPrint() {
+        return EnumUtils.prettyPrint(this);
+    }
+
+}

--- a/src/main/java/com/synopsys/integration/blackduck/api/generated/view/DeveloperScansScanView.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/generated/view/DeveloperScansScanView.java
@@ -7,6 +7,7 @@
  */
 package com.synopsys.integration.blackduck.api.generated.view;
 
+import java.math.BigDecimal;
 import com.synopsys.integration.blackduck.api.core.BlackDuckComponent;
 import com.synopsys.integration.blackduck.api.core.BlackDuckView;
 import com.synopsys.integration.blackduck.api.generated.component.DeveloperScansScanItemsComponentViolatingPoliciesView;
@@ -25,7 +26,9 @@ public class DeveloperScansScanView extends BlackDuckView {
     private java.util.List<java.util.List<String>> dependencyTrees;
     private String externalId;
     private java.util.List<DeveloperScansScanItemsFailedEvaluationPoliciesView> failedEvaluationPolicies;
+    private String filePath;
     private DeveloperScansScanItemsLongTermUpgradeGuidanceView longTermUpgradeGuidance;
+    private BigDecimal matchConfidence;
     private String originId;
     private java.util.List<String> policyStatuses;
     private java.util.List<DeveloperScansScanItemsPolicyViolationLicensesView> policyViolationLicenses;
@@ -82,12 +85,28 @@ public class DeveloperScansScanView extends BlackDuckView {
         this.failedEvaluationPolicies = failedEvaluationPolicies;
     }
 
+    public String getFilePath() {
+        return filePath;
+    }
+
+    public void setFilePath(String filePath) {
+        this.filePath = filePath;
+    }
+
     public DeveloperScansScanItemsLongTermUpgradeGuidanceView getLongTermUpgradeGuidance() {
         return longTermUpgradeGuidance;
     }
 
     public void setLongTermUpgradeGuidance(DeveloperScansScanItemsLongTermUpgradeGuidanceView longTermUpgradeGuidance) {
         this.longTermUpgradeGuidance = longTermUpgradeGuidance;
+    }
+
+    public BigDecimal getMatchConfidence() {
+        return matchConfidence;
+    }
+
+    public void setMatchConfidence(BigDecimal matchConfidence) {
+        this.matchConfidence = matchConfidence;
     }
 
     public String getOriginId() {

--- a/src/main/java/com/synopsys/integration/blackduck/api/generated/view/ProjectVersionBomStatusView.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/generated/view/ProjectVersionBomStatusView.java
@@ -5,13 +5,13 @@
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */
-package com.synopsys.integration.blackduck.api.generated.component;
+package com.synopsys.integration.blackduck.api.generated.view;
 
-import com.synopsys.integration.blackduck.api.core.BlackDuckComponent;
+import com.synopsys.integration.blackduck.api.core.BlackDuckView;
 import com.synopsys.integration.blackduck.api.generated.enumeration.ProjectVersionBomStatusType;
 
 // this file should not be edited - if changes are necessary, the generator should be updated, then this file should be re-created
-public class ProjectVersionBomStatusView extends BlackDuckComponent {
+public class ProjectVersionBomStatusView extends BlackDuckView {
     private java.util.Date lastBomUpdateDate;
     private java.util.Date lastScanDate;
     private ProjectVersionBomStatusType status;

--- a/src/main/java/com/synopsys/integration/blackduck/api/generated/view/ProjectVersionView.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/generated/view/ProjectVersionView.java
@@ -18,6 +18,7 @@ import com.synopsys.integration.blackduck.api.core.response.UrlMultipleResponses
 import com.synopsys.integration.blackduck.api.core.response.UrlSingleResponse;
 import com.synopsys.integration.blackduck.api.generated.enumeration.ProjectVersionDistributionType;
 import com.synopsys.integration.blackduck.api.generated.view.CodeLocationView;
+import com.synopsys.integration.blackduck.api.generated.view.ProjectVersionBomStatusView;
 import com.synopsys.integration.blackduck.api.generated.view.ProjectVersionComponentVersionView;
 import com.synopsys.integration.blackduck.api.generated.view.ProjectVersionIssuesView;
 import com.synopsys.integration.blackduck.api.generated.view.ProjectVersionLicenseView;
@@ -35,6 +36,7 @@ public class ProjectVersionView extends BlackDuckView {
     public static final Map<String, LinkBlackDuckResponse> links = new HashMap<>();
 
     public static final String ACTIVE_POLICY_RULES_LINK = "active-policy-rules";
+    public static final String BOM_STATUS_LINK = "bom-status";
     public static final String CODELOCATIONS_LINK = "codelocations";
     public static final String COMPONENTS_LINK = "components";
     public static final String ISSUES_LINK = "issues";
@@ -47,6 +49,7 @@ public class ProjectVersionView extends BlackDuckView {
     public static final String VULNERABLE_COMPONENTS_LINK = "vulnerable-components";
 
     public static final LinkMultipleResponses<ProjectVersionPolicyRulesView> ACTIVE_POLICY_RULES_LINK_RESPONSE = new LinkMultipleResponses<ProjectVersionPolicyRulesView>(ACTIVE_POLICY_RULES_LINK, ProjectVersionPolicyRulesView.class);
+    public static final LinkMultipleResponses<ProjectVersionBomStatusView> BOM_STATUS_LINK_RESPONSE = new LinkMultipleResponses<ProjectVersionBomStatusView>(BOM_STATUS_LINK, ProjectVersionBomStatusView.class);
     public static final LinkMultipleResponses<CodeLocationView> CODELOCATIONS_LINK_RESPONSE = new LinkMultipleResponses<CodeLocationView>(CODELOCATIONS_LINK, CodeLocationView.class);
     public static final LinkMultipleResponses<ProjectVersionComponentVersionView> COMPONENTS_LINK_RESPONSE = new LinkMultipleResponses<ProjectVersionComponentVersionView>(COMPONENTS_LINK, ProjectVersionComponentVersionView.class);
     public static final LinkMultipleResponses<ProjectVersionIssuesView> ISSUES_LINK_RESPONSE = new LinkMultipleResponses<ProjectVersionIssuesView>(ISSUES_LINK, ProjectVersionIssuesView.class);
@@ -60,6 +63,7 @@ public class ProjectVersionView extends BlackDuckView {
 
     static {
         links.put(ACTIVE_POLICY_RULES_LINK, ACTIVE_POLICY_RULES_LINK_RESPONSE);
+        links.put(BOM_STATUS_LINK, BOM_STATUS_LINK_RESPONSE);
         links.put(CODELOCATIONS_LINK, CODELOCATIONS_LINK_RESPONSE);
         links.put(COMPONENTS_LINK, COMPONENTS_LINK_RESPONSE);
         links.put(ISSUES_LINK, ISSUES_LINK_RESPONSE);
@@ -232,6 +236,14 @@ public class ProjectVersionView extends BlackDuckView {
 
     public Optional<UrlMultipleResponses<ProjectVersionPolicyRulesView>> metaActivePolicyRulesLinkSafely() {
         return metaMultipleResponsesSafely(ACTIVE_POLICY_RULES_LINK_RESPONSE);
+    }
+
+    public UrlMultipleResponses<ProjectVersionBomStatusView> metaBomStatusLink() {
+        return metaMultipleResponses(BOM_STATUS_LINK_RESPONSE);
+    }
+
+    public Optional<UrlMultipleResponses<ProjectVersionBomStatusView>> metaBomStatusLinkSafely() {
+        return metaMultipleResponsesSafely(BOM_STATUS_LINK_RESPONSE);
     }
 
     public UrlMultipleResponses<CodeLocationView> metaCodelocationsLink() {


### PR DESCRIPTION
This generates against the 2022.10 spec.

The generator was changed so ProjectVersionBomStatusView is correctly generated as a BlackDuckView. See: https://github.com/blackducksoftware/blackduck-common-apigen/pull/17

Some of the new SBOM classes were not sourced as there are problems with the BlackDuck definition. See: https://jira-sig.internal.synopsys.com/browse/HUB-36345