### PR TITLE
fix bom status scan level view

### DIFF
--- a/src/main/java/com/synopsys/integration/blackduck/api/generated/component/BomStatusScanView.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/generated/component/BomStatusScanView.java
@@ -7,11 +7,11 @@
  */
 package com.synopsys.integration.blackduck.api.generated.component;
 
-import com.synopsys.integration.blackduck.api.core.BlackDuckComponent;
+import com.synopsys.integration.blackduck.api.core.BlackDuckView;
 import com.synopsys.integration.blackduck.api.generated.enumeration.BomStatusScanStatusType;
 
 // this file should not be edited - if changes are necessary, the generator should be updated, then this file should be re-created
-public class BomStatusScanView extends BlackDuckComponent {
+public class BomStatusScanView extends BlackDuckView {
     private BomStatusScanStatusType status;
 
     public BomStatusScanStatusType getStatus() {

--- a/src/main/java/com/synopsys/integration/blackduck/api/generated/view/BomStatusScanView.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/generated/view/BomStatusScanView.java
@@ -1,11 +1,4 @@
-/*
- * blackduck-common-api
- *
- * Copyright (c) 2022 Synopsys, Inc.
- *
- * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
- */
-package com.synopsys.integration.blackduck.api.generated.component;
+package com.synopsys.integration.blackduck.api.generated.view;
 
 import com.synopsys.integration.blackduck.api.core.BlackDuckView;
 import com.synopsys.integration.blackduck.api.generated.enumeration.BomStatusScanStatusType;

--- a/src/main/java/com/synopsys/integration/blackduck/api/generated/view/BomStatusScanView.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/generated/view/BomStatusScanView.java
@@ -1,3 +1,10 @@
+/*
+ * blackduck-common-api
+ *
+ * Copyright (c) 2022 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
 package com.synopsys.integration.blackduck.api.generated.view;
 
 import com.synopsys.integration.blackduck.api.core.BlackDuckView;


### PR DESCRIPTION
The generation seems to have removed the copyright, I can manually add it back if we wish. This is similar to the work we did for the project level bom-status classes, need to do it at the scan level now.