### PR TITLE
IDETECT-3547 - Upgrade Guidance on transitive dependancies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
 project.ext.moduleName = 'com.synopsys.integration.blackduck-common-api'
 project.ext.javaUseAutoModuleName = 'true'
 
-version = '2022.10.6-SNAPSHOT'
+version = '2023.1.0-SNAPSHOT'
 
 description = 'A library of mostly temporary request/response classes for the Black Duck REST API.'
 

--- a/src/main/java/com/synopsys/integration/blackduck/api/generated/component/CodeLocationLatestScanSummaryView.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/generated/component/CodeLocationLatestScanSummaryView.java
@@ -25,6 +25,7 @@ public class CodeLocationLatestScanSummaryView extends BlackDuckComponent {
     private BigDecimal fileCount;
     private String hostName;
     private BigDecimal matchCount;
+    private Boolean retainUnmatchedFiles;
     private BigDecimal scanSize;
     private ScanStateType scanState;
     private ScanType scanType;
@@ -95,6 +96,14 @@ public class CodeLocationLatestScanSummaryView extends BlackDuckComponent {
 
     public void setMatchCount(BigDecimal matchCount) {
         this.matchCount = matchCount;
+    }
+
+    public Boolean getRetainUnmatchedFiles() {
+        return retainUnmatchedFiles;
+    }
+
+    public void setRetainUnmatchedFiles(Boolean retainUnmatchedFiles) {
+        this.retainUnmatchedFiles = retainUnmatchedFiles;
     }
 
     public BigDecimal getScanSize() {

--- a/src/main/java/com/synopsys/integration/blackduck/api/generated/component/ComponentVersionSbomFieldsItemsValueView.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/generated/component/ComponentVersionSbomFieldsItemsValueView.java
@@ -1,0 +1,43 @@
+/*
+ * blackduck-common-api
+ *
+ * Copyright (c) 2023 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
+package com.synopsys.integration.blackduck.api.generated.component;
+
+import com.synopsys.integration.blackduck.api.core.BlackDuckComponent;
+import com.synopsys.integration.blackduck.api.generated.enumeration.ComponentVersionSbomFieldsItemsValueType;
+
+// this file should not be edited - if changes are necessary, the generator should be updated, then this file should be re-created
+public class ComponentVersionSbomFieldsItemsValueView extends BlackDuckComponent {
+    private String email;
+    private String name;
+    private ComponentVersionSbomFieldsItemsValueType type;
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public ComponentVersionSbomFieldsItemsValueType getType() {
+        return type;
+    }
+
+    public void setType(ComponentVersionSbomFieldsItemsValueType type) {
+        this.type = type;
+    }
+
+}

--- a/src/main/java/com/synopsys/integration/blackduck/api/generated/component/ComponentVersionSbomFieldsView.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/generated/component/ComponentVersionSbomFieldsView.java
@@ -1,0 +1,43 @@
+/*
+ * blackduck-common-api
+ *
+ * Copyright (c) 2023 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
+package com.synopsys.integration.blackduck.api.generated.component;
+
+import com.synopsys.integration.blackduck.api.core.BlackDuckComponent;
+import com.synopsys.integration.blackduck.api.generated.component.ComponentVersionSbomFieldsItemsValueView;
+
+// this file should not be edited - if changes are necessary, the generator should be updated, then this file should be re-created
+public class ComponentVersionSbomFieldsView extends BlackDuckComponent {
+    private String fieldName;
+    private String label;
+    private ComponentVersionSbomFieldsItemsValueView value;
+
+    public String getFieldName() {
+        return fieldName;
+    }
+
+    public void setFieldName(String fieldName) {
+        this.fieldName = fieldName;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public void setLabel(String label) {
+        this.label = label;
+    }
+
+    public ComponentVersionSbomFieldsItemsValueView getValue() {
+        return value;
+    }
+
+    public void setValue(ComponentVersionSbomFieldsItemsValueView value) {
+        this.value = value;
+    }
+
+}

--- a/src/main/java/com/synopsys/integration/blackduck/api/generated/component/DeveloperScansScanItemsTransitiveUpgradeGuidanceLongTermUpgradeGuidanceView.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/generated/component/DeveloperScansScanItemsTransitiveUpgradeGuidanceLongTermUpgradeGuidanceView.java
@@ -1,0 +1,34 @@
+/*
+ * blackduck-common-api
+ *
+ * Copyright (c) 2023 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
+package com.synopsys.integration.blackduck.api.generated.component;
+
+import com.synopsys.integration.blackduck.api.core.BlackDuckComponent;
+import com.synopsys.integration.blackduck.api.generated.component.DeveloperScansScanItemsTransitiveUpgradeGuidanceLongTermUpgradeGuidanceVulnerabilityRiskView;
+
+// this file should not be edited - if changes are necessary, the generator should be updated, then this file should be re-created
+public class DeveloperScansScanItemsTransitiveUpgradeGuidanceLongTermUpgradeGuidanceView extends BlackDuckComponent {
+    private String versionName;
+    private DeveloperScansScanItemsTransitiveUpgradeGuidanceLongTermUpgradeGuidanceVulnerabilityRiskView vulnerabilityRisk;
+
+    public String getVersionName() {
+        return versionName;
+    }
+
+    public void setVersionName(String versionName) {
+        this.versionName = versionName;
+    }
+
+    public DeveloperScansScanItemsTransitiveUpgradeGuidanceLongTermUpgradeGuidanceVulnerabilityRiskView getVulnerabilityRisk() {
+        return vulnerabilityRisk;
+    }
+
+    public void setVulnerabilityRisk(DeveloperScansScanItemsTransitiveUpgradeGuidanceLongTermUpgradeGuidanceVulnerabilityRiskView vulnerabilityRisk) {
+        this.vulnerabilityRisk = vulnerabilityRisk;
+    }
+
+}

--- a/src/main/java/com/synopsys/integration/blackduck/api/generated/component/DeveloperScansScanItemsTransitiveUpgradeGuidanceLongTermUpgradeGuidanceVulnerabilityRiskView.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/generated/component/DeveloperScansScanItemsTransitiveUpgradeGuidanceLongTermUpgradeGuidanceVulnerabilityRiskView.java
@@ -1,0 +1,61 @@
+/*
+ * blackduck-common-api
+ *
+ * Copyright (c) 2023 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
+package com.synopsys.integration.blackduck.api.generated.component;
+
+import java.math.BigDecimal;
+import com.synopsys.integration.blackduck.api.core.BlackDuckComponent;
+
+// this file should not be edited - if changes are necessary, the generator should be updated, then this file should be re-created
+public class DeveloperScansScanItemsTransitiveUpgradeGuidanceLongTermUpgradeGuidanceVulnerabilityRiskView extends BlackDuckComponent {
+    private BigDecimal critical;
+    private BigDecimal high;
+    private BigDecimal low;
+    private BigDecimal medium;
+    private BigDecimal unscored;
+
+    public BigDecimal getCritical() {
+        return critical;
+    }
+
+    public void setCritical(BigDecimal critical) {
+        this.critical = critical;
+    }
+
+    public BigDecimal getHigh() {
+        return high;
+    }
+
+    public void setHigh(BigDecimal high) {
+        this.high = high;
+    }
+
+    public BigDecimal getLow() {
+        return low;
+    }
+
+    public void setLow(BigDecimal low) {
+        this.low = low;
+    }
+
+    public BigDecimal getMedium() {
+        return medium;
+    }
+
+    public void setMedium(BigDecimal medium) {
+        this.medium = medium;
+    }
+
+    public BigDecimal getUnscored() {
+        return unscored;
+    }
+
+    public void setUnscored(BigDecimal unscored) {
+        this.unscored = unscored;
+    }
+
+}

--- a/src/main/java/com/synopsys/integration/blackduck/api/generated/component/DeveloperScansScanItemsTransitiveUpgradeGuidanceShortTermUpgradeGuidanceView.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/generated/component/DeveloperScansScanItemsTransitiveUpgradeGuidanceShortTermUpgradeGuidanceView.java
@@ -1,0 +1,34 @@
+/*
+ * blackduck-common-api
+ *
+ * Copyright (c) 2023 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
+package com.synopsys.integration.blackduck.api.generated.component;
+
+import com.synopsys.integration.blackduck.api.core.BlackDuckComponent;
+import com.synopsys.integration.blackduck.api.generated.component.DeveloperScansScanItemsTransitiveUpgradeGuidanceShortTermUpgradeGuidanceVulnerabilityRiskView;
+
+// this file should not be edited - if changes are necessary, the generator should be updated, then this file should be re-created
+public class DeveloperScansScanItemsTransitiveUpgradeGuidanceShortTermUpgradeGuidanceView extends BlackDuckComponent {
+    private String versionName;
+    private DeveloperScansScanItemsTransitiveUpgradeGuidanceShortTermUpgradeGuidanceVulnerabilityRiskView vulnerabilityRisk;
+
+    public String getVersionName() {
+        return versionName;
+    }
+
+    public void setVersionName(String versionName) {
+        this.versionName = versionName;
+    }
+
+    public DeveloperScansScanItemsTransitiveUpgradeGuidanceShortTermUpgradeGuidanceVulnerabilityRiskView getVulnerabilityRisk() {
+        return vulnerabilityRisk;
+    }
+
+    public void setVulnerabilityRisk(DeveloperScansScanItemsTransitiveUpgradeGuidanceShortTermUpgradeGuidanceVulnerabilityRiskView vulnerabilityRisk) {
+        this.vulnerabilityRisk = vulnerabilityRisk;
+    }
+
+}

--- a/src/main/java/com/synopsys/integration/blackduck/api/generated/component/DeveloperScansScanItemsTransitiveUpgradeGuidanceShortTermUpgradeGuidanceVulnerabilityRiskView.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/generated/component/DeveloperScansScanItemsTransitiveUpgradeGuidanceShortTermUpgradeGuidanceVulnerabilityRiskView.java
@@ -1,0 +1,61 @@
+/*
+ * blackduck-common-api
+ *
+ * Copyright (c) 2023 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
+package com.synopsys.integration.blackduck.api.generated.component;
+
+import java.math.BigDecimal;
+import com.synopsys.integration.blackduck.api.core.BlackDuckComponent;
+
+// this file should not be edited - if changes are necessary, the generator should be updated, then this file should be re-created
+public class DeveloperScansScanItemsTransitiveUpgradeGuidanceShortTermUpgradeGuidanceVulnerabilityRiskView extends BlackDuckComponent {
+    private BigDecimal critical;
+    private BigDecimal high;
+    private BigDecimal low;
+    private BigDecimal medium;
+    private BigDecimal unscored;
+
+    public BigDecimal getCritical() {
+        return critical;
+    }
+
+    public void setCritical(BigDecimal critical) {
+        this.critical = critical;
+    }
+
+    public BigDecimal getHigh() {
+        return high;
+    }
+
+    public void setHigh(BigDecimal high) {
+        this.high = high;
+    }
+
+    public BigDecimal getLow() {
+        return low;
+    }
+
+    public void setLow(BigDecimal low) {
+        this.low = low;
+    }
+
+    public BigDecimal getMedium() {
+        return medium;
+    }
+
+    public void setMedium(BigDecimal medium) {
+        this.medium = medium;
+    }
+
+    public BigDecimal getUnscored() {
+        return unscored;
+    }
+
+    public void setUnscored(BigDecimal unscored) {
+        this.unscored = unscored;
+    }
+
+}

--- a/src/main/java/com/synopsys/integration/blackduck/api/generated/component/DeveloperScansScanItemsTransitiveUpgradeGuidanceView.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/generated/component/DeveloperScansScanItemsTransitiveUpgradeGuidanceView.java
@@ -1,0 +1,44 @@
+/*
+ * blackduck-common-api
+ *
+ * Copyright (c) 2023 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
+package com.synopsys.integration.blackduck.api.generated.component;
+
+import com.synopsys.integration.blackduck.api.core.BlackDuckComponent;
+import com.synopsys.integration.blackduck.api.generated.component.DeveloperScansScanItemsTransitiveUpgradeGuidanceLongTermUpgradeGuidanceView;
+import com.synopsys.integration.blackduck.api.generated.component.DeveloperScansScanItemsTransitiveUpgradeGuidanceShortTermUpgradeGuidanceView;
+
+// this file should not be edited - if changes are necessary, the generator should be updated, then this file should be re-created
+public class DeveloperScansScanItemsTransitiveUpgradeGuidanceView extends BlackDuckComponent {
+    private String externalId;
+    private DeveloperScansScanItemsTransitiveUpgradeGuidanceLongTermUpgradeGuidanceView longTermUpgradeGuidance;
+    private DeveloperScansScanItemsTransitiveUpgradeGuidanceShortTermUpgradeGuidanceView shortTermUpgradeGuidance;
+
+    public String getExternalId() {
+        return externalId;
+    }
+
+    public void setExternalId(String externalId) {
+        this.externalId = externalId;
+    }
+
+    public DeveloperScansScanItemsTransitiveUpgradeGuidanceLongTermUpgradeGuidanceView getLongTermUpgradeGuidance() {
+        return longTermUpgradeGuidance;
+    }
+
+    public void setLongTermUpgradeGuidance(DeveloperScansScanItemsTransitiveUpgradeGuidanceLongTermUpgradeGuidanceView longTermUpgradeGuidance) {
+        this.longTermUpgradeGuidance = longTermUpgradeGuidance;
+    }
+
+    public DeveloperScansScanItemsTransitiveUpgradeGuidanceShortTermUpgradeGuidanceView getShortTermUpgradeGuidance() {
+        return shortTermUpgradeGuidance;
+    }
+
+    public void setShortTermUpgradeGuidance(DeveloperScansScanItemsTransitiveUpgradeGuidanceShortTermUpgradeGuidanceView shortTermUpgradeGuidance) {
+        this.shortTermUpgradeGuidance = shortTermUpgradeGuidance;
+    }
+
+}

--- a/src/main/java/com/synopsys/integration/blackduck/api/generated/component/OriginTransitiveUpgradeGuidanceLongTermView.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/generated/component/OriginTransitiveUpgradeGuidanceLongTermView.java
@@ -1,0 +1,79 @@
+/*
+ * blackduck-common-api
+ *
+ * Copyright (c) 2023 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
+package com.synopsys.integration.blackduck.api.generated.component;
+
+import com.synopsys.integration.blackduck.api.core.BlackDuckComponent;
+import com.synopsys.integration.blackduck.api.generated.component.OriginTransitiveUpgradeGuidanceLongTermVulnerabilityRiskView;
+
+// this file should not be edited - if changes are necessary, the generator should be updated, then this file should be re-created
+public class OriginTransitiveUpgradeGuidanceLongTermView extends BlackDuckComponent {
+    private String origin;
+    private String originExternalId;
+    private String originExternalNamespace;
+    private String originName;
+    private String version;
+    private String versionName;
+    private OriginTransitiveUpgradeGuidanceLongTermVulnerabilityRiskView vulnerabilityRisk;
+
+    public String getOrigin() {
+        return origin;
+    }
+
+    public void setOrigin(String origin) {
+        this.origin = origin;
+    }
+
+    public String getOriginExternalId() {
+        return originExternalId;
+    }
+
+    public void setOriginExternalId(String originExternalId) {
+        this.originExternalId = originExternalId;
+    }
+
+    public String getOriginExternalNamespace() {
+        return originExternalNamespace;
+    }
+
+    public void setOriginExternalNamespace(String originExternalNamespace) {
+        this.originExternalNamespace = originExternalNamespace;
+    }
+
+    public String getOriginName() {
+        return originName;
+    }
+
+    public void setOriginName(String originName) {
+        this.originName = originName;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public String getVersionName() {
+        return versionName;
+    }
+
+    public void setVersionName(String versionName) {
+        this.versionName = versionName;
+    }
+
+    public OriginTransitiveUpgradeGuidanceLongTermVulnerabilityRiskView getVulnerabilityRisk() {
+        return vulnerabilityRisk;
+    }
+
+    public void setVulnerabilityRisk(OriginTransitiveUpgradeGuidanceLongTermVulnerabilityRiskView vulnerabilityRisk) {
+        this.vulnerabilityRisk = vulnerabilityRisk;
+    }
+
+}

--- a/src/main/java/com/synopsys/integration/blackduck/api/generated/component/OriginTransitiveUpgradeGuidanceLongTermVulnerabilityRiskView.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/generated/component/OriginTransitiveUpgradeGuidanceLongTermVulnerabilityRiskView.java
@@ -1,0 +1,52 @@
+/*
+ * blackduck-common-api
+ *
+ * Copyright (c) 2023 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
+package com.synopsys.integration.blackduck.api.generated.component;
+
+import java.math.BigDecimal;
+import com.synopsys.integration.blackduck.api.core.BlackDuckComponent;
+
+// this file should not be edited - if changes are necessary, the generator should be updated, then this file should be re-created
+public class OriginTransitiveUpgradeGuidanceLongTermVulnerabilityRiskView extends BlackDuckComponent {
+    private BigDecimal critical;
+    private BigDecimal high;
+    private BigDecimal low;
+    private BigDecimal medium;
+
+    public BigDecimal getCritical() {
+        return critical;
+    }
+
+    public void setCritical(BigDecimal critical) {
+        this.critical = critical;
+    }
+
+    public BigDecimal getHigh() {
+        return high;
+    }
+
+    public void setHigh(BigDecimal high) {
+        this.high = high;
+    }
+
+    public BigDecimal getLow() {
+        return low;
+    }
+
+    public void setLow(BigDecimal low) {
+        this.low = low;
+    }
+
+    public BigDecimal getMedium() {
+        return medium;
+    }
+
+    public void setMedium(BigDecimal medium) {
+        this.medium = medium;
+    }
+
+}

--- a/src/main/java/com/synopsys/integration/blackduck/api/generated/component/OriginTransitiveUpgradeGuidanceShortTermView.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/generated/component/OriginTransitiveUpgradeGuidanceShortTermView.java
@@ -1,0 +1,79 @@
+/*
+ * blackduck-common-api
+ *
+ * Copyright (c) 2023 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
+package com.synopsys.integration.blackduck.api.generated.component;
+
+import com.synopsys.integration.blackduck.api.core.BlackDuckComponent;
+import com.synopsys.integration.blackduck.api.generated.component.OriginTransitiveUpgradeGuidanceShortTermVulnerabilityRiskView;
+
+// this file should not be edited - if changes are necessary, the generator should be updated, then this file should be re-created
+public class OriginTransitiveUpgradeGuidanceShortTermView extends BlackDuckComponent {
+    private String origin;
+    private String originExternalId;
+    private String originExternalNamespace;
+    private String originName;
+    private String version;
+    private String versionName;
+    private OriginTransitiveUpgradeGuidanceShortTermVulnerabilityRiskView vulnerabilityRisk;
+
+    public String getOrigin() {
+        return origin;
+    }
+
+    public void setOrigin(String origin) {
+        this.origin = origin;
+    }
+
+    public String getOriginExternalId() {
+        return originExternalId;
+    }
+
+    public void setOriginExternalId(String originExternalId) {
+        this.originExternalId = originExternalId;
+    }
+
+    public String getOriginExternalNamespace() {
+        return originExternalNamespace;
+    }
+
+    public void setOriginExternalNamespace(String originExternalNamespace) {
+        this.originExternalNamespace = originExternalNamespace;
+    }
+
+    public String getOriginName() {
+        return originName;
+    }
+
+    public void setOriginName(String originName) {
+        this.originName = originName;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public String getVersionName() {
+        return versionName;
+    }
+
+    public void setVersionName(String versionName) {
+        this.versionName = versionName;
+    }
+
+    public OriginTransitiveUpgradeGuidanceShortTermVulnerabilityRiskView getVulnerabilityRisk() {
+        return vulnerabilityRisk;
+    }
+
+    public void setVulnerabilityRisk(OriginTransitiveUpgradeGuidanceShortTermVulnerabilityRiskView vulnerabilityRisk) {
+        this.vulnerabilityRisk = vulnerabilityRisk;
+    }
+
+}

--- a/src/main/java/com/synopsys/integration/blackduck/api/generated/component/OriginTransitiveUpgradeGuidanceShortTermVulnerabilityRiskView.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/generated/component/OriginTransitiveUpgradeGuidanceShortTermVulnerabilityRiskView.java
@@ -1,0 +1,52 @@
+/*
+ * blackduck-common-api
+ *
+ * Copyright (c) 2023 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
+package com.synopsys.integration.blackduck.api.generated.component;
+
+import java.math.BigDecimal;
+import com.synopsys.integration.blackduck.api.core.BlackDuckComponent;
+
+// this file should not be edited - if changes are necessary, the generator should be updated, then this file should be re-created
+public class OriginTransitiveUpgradeGuidanceShortTermVulnerabilityRiskView extends BlackDuckComponent {
+    private BigDecimal critical;
+    private BigDecimal high;
+    private BigDecimal low;
+    private BigDecimal medium;
+
+    public BigDecimal getCritical() {
+        return critical;
+    }
+
+    public void setCritical(BigDecimal critical) {
+        this.critical = critical;
+    }
+
+    public BigDecimal getHigh() {
+        return high;
+    }
+
+    public void setHigh(BigDecimal high) {
+        this.high = high;
+    }
+
+    public BigDecimal getLow() {
+        return low;
+    }
+
+    public void setLow(BigDecimal low) {
+        this.low = low;
+    }
+
+    public BigDecimal getMedium() {
+        return medium;
+    }
+
+    public void setMedium(BigDecimal medium) {
+        this.medium = medium;
+    }
+
+}

--- a/src/main/java/com/synopsys/integration/blackduck/api/generated/component/OriginTransitiveUpgradeGuidanceView.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/generated/component/OriginTransitiveUpgradeGuidanceView.java
@@ -1,0 +1,107 @@
+/*
+ * blackduck-common-api
+ *
+ * Copyright (c) 2023 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
+package com.synopsys.integration.blackduck.api.generated.component;
+
+import com.synopsys.integration.blackduck.api.core.BlackDuckComponent;
+import com.synopsys.integration.blackduck.api.generated.component.OriginTransitiveUpgradeGuidanceLongTermView;
+import com.synopsys.integration.blackduck.api.generated.component.OriginTransitiveUpgradeGuidanceShortTermView;
+
+// this file should not be edited - if changes are necessary, the generator should be updated, then this file should be re-created
+public class OriginTransitiveUpgradeGuidanceView extends BlackDuckComponent {
+    private String component;
+    private String componentName;
+    private OriginTransitiveUpgradeGuidanceLongTermView longTerm;
+    private String origin;
+    private String originExternalId;
+    private String originExternalNamespace;
+    private String originName;
+    private OriginTransitiveUpgradeGuidanceShortTermView shortTerm;
+    private String version;
+    private String versionName;
+
+    public String getComponent() {
+        return component;
+    }
+
+    public void setComponent(String component) {
+        this.component = component;
+    }
+
+    public String getComponentName() {
+        return componentName;
+    }
+
+    public void setComponentName(String componentName) {
+        this.componentName = componentName;
+    }
+
+    public OriginTransitiveUpgradeGuidanceLongTermView getLongTerm() {
+        return longTerm;
+    }
+
+    public void setLongTerm(OriginTransitiveUpgradeGuidanceLongTermView longTerm) {
+        this.longTerm = longTerm;
+    }
+
+    public String getOrigin() {
+        return origin;
+    }
+
+    public void setOrigin(String origin) {
+        this.origin = origin;
+    }
+
+    public String getOriginExternalId() {
+        return originExternalId;
+    }
+
+    public void setOriginExternalId(String originExternalId) {
+        this.originExternalId = originExternalId;
+    }
+
+    public String getOriginExternalNamespace() {
+        return originExternalNamespace;
+    }
+
+    public void setOriginExternalNamespace(String originExternalNamespace) {
+        this.originExternalNamespace = originExternalNamespace;
+    }
+
+    public String getOriginName() {
+        return originName;
+    }
+
+    public void setOriginName(String originName) {
+        this.originName = originName;
+    }
+
+    public OriginTransitiveUpgradeGuidanceShortTermView getShortTerm() {
+        return shortTerm;
+    }
+
+    public void setShortTerm(OriginTransitiveUpgradeGuidanceShortTermView shortTerm) {
+        this.shortTerm = shortTerm;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public String getVersionName() {
+        return versionName;
+    }
+
+    public void setVersionName(String versionName) {
+        this.versionName = versionName;
+    }
+
+}

--- a/src/main/java/com/synopsys/integration/blackduck/api/generated/component/ProjectGroupSbomFieldsItemsValueView.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/generated/component/ProjectGroupSbomFieldsItemsValueView.java
@@ -1,0 +1,51 @@
+/*
+ * blackduck-common-api
+ *
+ * Copyright (c) 2023 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
+package com.synopsys.integration.blackduck.api.generated.component;
+
+import com.synopsys.integration.blackduck.api.core.BlackDuckComponent;
+
+// this file should not be edited - if changes are necessary, the generator should be updated, then this file should be re-created
+public class ProjectGroupSbomFieldsItemsValueView extends BlackDuckComponent {
+    private String organizationEmail;
+    private String organizationName;
+    private String personEmail;
+    private String personName;
+
+    public String getOrganizationEmail() {
+        return organizationEmail;
+    }
+
+    public void setOrganizationEmail(String organizationEmail) {
+        this.organizationEmail = organizationEmail;
+    }
+
+    public String getOrganizationName() {
+        return organizationName;
+    }
+
+    public void setOrganizationName(String organizationName) {
+        this.organizationName = organizationName;
+    }
+
+    public String getPersonEmail() {
+        return personEmail;
+    }
+
+    public void setPersonEmail(String personEmail) {
+        this.personEmail = personEmail;
+    }
+
+    public String getPersonName() {
+        return personName;
+    }
+
+    public void setPersonName(String personName) {
+        this.personName = personName;
+    }
+
+}

--- a/src/main/java/com/synopsys/integration/blackduck/api/generated/component/ProjectGroupSbomFieldsView.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/generated/component/ProjectGroupSbomFieldsView.java
@@ -1,0 +1,43 @@
+/*
+ * blackduck-common-api
+ *
+ * Copyright (c) 2023 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
+package com.synopsys.integration.blackduck.api.generated.component;
+
+import com.synopsys.integration.blackduck.api.core.BlackDuckComponent;
+import com.synopsys.integration.blackduck.api.generated.component.ProjectGroupSbomFieldsItemsValueView;
+
+// this file should not be edited - if changes are necessary, the generator should be updated, then this file should be re-created
+public class ProjectGroupSbomFieldsView extends BlackDuckComponent {
+    private String fieldName;
+    private String label;
+    private ProjectGroupSbomFieldsItemsValueView value;
+
+    public String getFieldName() {
+        return fieldName;
+    }
+
+    public void setFieldName(String fieldName) {
+        this.fieldName = fieldName;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public void setLabel(String label) {
+        this.label = label;
+    }
+
+    public ProjectGroupSbomFieldsItemsValueView getValue() {
+        return value;
+    }
+
+    public void setValue(ProjectGroupSbomFieldsItemsValueView value) {
+        this.value = value;
+    }
+
+}

--- a/src/main/java/com/synopsys/integration/blackduck/api/generated/component/ProjectGroupsProjectGroupView.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/generated/component/ProjectGroupsProjectGroupView.java
@@ -14,11 +14,21 @@ import com.synopsys.integration.blackduck.api.core.response.LinkBlackDuckRespons
 
 // this file should not be edited - if changes are necessary, the generator should be updated, then this file should be re-created
 public class ProjectGroupsProjectGroupView extends BlackDuckComponent {
+    private java.util.Date createdAt;
     private BigDecimal depth;
     private String description;
     private BigDecimal directChildProjectCount;
     private BigDecimal directChildProjectGroupCount;
     private String name;
+    private java.util.Date updatedAt;
+
+    public java.util.Date getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(java.util.Date createdAt) {
+        this.createdAt = createdAt;
+    }
 
     public BigDecimal getDepth() {
         return depth;
@@ -58,6 +68,14 @@ public class ProjectGroupsProjectGroupView extends BlackDuckComponent {
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    public java.util.Date getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(java.util.Date updatedAt) {
+        this.updatedAt = updatedAt;
     }
 
 }

--- a/src/main/java/com/synopsys/integration/blackduck/api/generated/component/ProjectVersionComponentSbomFieldsItemsValueView.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/generated/component/ProjectVersionComponentSbomFieldsItemsValueView.java
@@ -1,0 +1,43 @@
+/*
+ * blackduck-common-api
+ *
+ * Copyright (c) 2023 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
+package com.synopsys.integration.blackduck.api.generated.component;
+
+import com.synopsys.integration.blackduck.api.core.BlackDuckComponent;
+import com.synopsys.integration.blackduck.api.generated.enumeration.ComponentVersionSbomFieldsItemsValueType;
+
+// this file should not be edited - if changes are necessary, the generator should be updated, then this file should be re-created
+public class ProjectVersionComponentSbomFieldsItemsValueView extends BlackDuckComponent {
+    private String email;
+    private String name;
+    private ComponentVersionSbomFieldsItemsValueType type;
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public ComponentVersionSbomFieldsItemsValueType getType() {
+        return type;
+    }
+
+    public void setType(ComponentVersionSbomFieldsItemsValueType type) {
+        this.type = type;
+    }
+
+}

--- a/src/main/java/com/synopsys/integration/blackduck/api/generated/component/ProjectVersionComponentSbomFieldsView.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/generated/component/ProjectVersionComponentSbomFieldsView.java
@@ -1,0 +1,43 @@
+/*
+ * blackduck-common-api
+ *
+ * Copyright (c) 2023 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
+package com.synopsys.integration.blackduck.api.generated.component;
+
+import com.synopsys.integration.blackduck.api.core.BlackDuckComponent;
+import com.synopsys.integration.blackduck.api.generated.component.ProjectVersionComponentSbomFieldsItemsValueView;
+
+// this file should not be edited - if changes are necessary, the generator should be updated, then this file should be re-created
+public class ProjectVersionComponentSbomFieldsView extends BlackDuckComponent {
+    private String fieldName;
+    private String label;
+    private ProjectVersionComponentSbomFieldsItemsValueView value;
+
+    public String getFieldName() {
+        return fieldName;
+    }
+
+    public void setFieldName(String fieldName) {
+        this.fieldName = fieldName;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public void setLabel(String label) {
+        this.label = label;
+    }
+
+    public ProjectVersionComponentSbomFieldsItemsValueView getValue() {
+        return value;
+    }
+
+    public void setValue(ProjectVersionComponentSbomFieldsItemsValueView value) {
+        this.value = value;
+    }
+
+}

--- a/src/main/java/com/synopsys/integration/blackduck/api/generated/component/ProjectVersionMatchedFilesItemsMatchesView.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/generated/component/ProjectVersionMatchedFilesItemsMatchesView.java
@@ -10,12 +10,14 @@ package com.synopsys.integration.blackduck.api.generated.component;
 import java.math.BigDecimal;
 import com.synopsys.integration.blackduck.api.core.BlackDuckComponent;
 import com.synopsys.integration.blackduck.api.generated.enumeration.MatchType;
+import com.synopsys.integration.blackduck.api.generated.enumeration.ProjectVersionMatchedFilesItemsMatchesMatchTypeFilterValueType;
 
 // this file should not be edited - if changes are necessary, the generator should be updated, then this file should be re-created
 public class ProjectVersionMatchedFilesItemsMatchesView extends BlackDuckComponent {
     private String component;
     private BigDecimal matchConfidencePercentage;
     private java.util.List<MatchType> matchType;
+    private ProjectVersionMatchedFilesItemsMatchesMatchTypeFilterValueType matchTypeFilterValue;
     private String snippet;
 
     public String getComponent() {
@@ -40,6 +42,14 @@ public class ProjectVersionMatchedFilesItemsMatchesView extends BlackDuckCompone
 
     public void setMatchType(java.util.List<MatchType> matchType) {
         this.matchType = matchType;
+    }
+
+    public ProjectVersionMatchedFilesItemsMatchesMatchTypeFilterValueType getMatchTypeFilterValue() {
+        return matchTypeFilterValue;
+    }
+
+    public void setMatchTypeFilterValue(ProjectVersionMatchedFilesItemsMatchesMatchTypeFilterValueType matchTypeFilterValue) {
+        this.matchTypeFilterValue = matchTypeFilterValue;
     }
 
     public String getSnippet() {

--- a/src/main/java/com/synopsys/integration/blackduck/api/generated/component/ScanFullResultItemsTransitiveUpgradeGuidanceLongTermUpgradeGuidanceView.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/generated/component/ScanFullResultItemsTransitiveUpgradeGuidanceLongTermUpgradeGuidanceView.java
@@ -1,0 +1,34 @@
+/*
+ * blackduck-common-api
+ *
+ * Copyright (c) 2023 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
+package com.synopsys.integration.blackduck.api.generated.component;
+
+import com.synopsys.integration.blackduck.api.core.BlackDuckComponent;
+import com.synopsys.integration.blackduck.api.generated.component.ScanFullResultItemsTransitiveUpgradeGuidanceLongTermUpgradeGuidanceVulnerabilityRiskView;
+
+// this file should not be edited - if changes are necessary, the generator should be updated, then this file should be re-created
+public class ScanFullResultItemsTransitiveUpgradeGuidanceLongTermUpgradeGuidanceView extends BlackDuckComponent {
+    private String versionName;
+    private ScanFullResultItemsTransitiveUpgradeGuidanceLongTermUpgradeGuidanceVulnerabilityRiskView vulnerabilityRisk;
+
+    public String getVersionName() {
+        return versionName;
+    }
+
+    public void setVersionName(String versionName) {
+        this.versionName = versionName;
+    }
+
+    public ScanFullResultItemsTransitiveUpgradeGuidanceLongTermUpgradeGuidanceVulnerabilityRiskView getVulnerabilityRisk() {
+        return vulnerabilityRisk;
+    }
+
+    public void setVulnerabilityRisk(ScanFullResultItemsTransitiveUpgradeGuidanceLongTermUpgradeGuidanceVulnerabilityRiskView vulnerabilityRisk) {
+        this.vulnerabilityRisk = vulnerabilityRisk;
+    }
+
+}

--- a/src/main/java/com/synopsys/integration/blackduck/api/generated/component/ScanFullResultItemsTransitiveUpgradeGuidanceLongTermUpgradeGuidanceVulnerabilityRiskView.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/generated/component/ScanFullResultItemsTransitiveUpgradeGuidanceLongTermUpgradeGuidanceVulnerabilityRiskView.java
@@ -1,0 +1,61 @@
+/*
+ * blackduck-common-api
+ *
+ * Copyright (c) 2023 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
+package com.synopsys.integration.blackduck.api.generated.component;
+
+import java.math.BigDecimal;
+import com.synopsys.integration.blackduck.api.core.BlackDuckComponent;
+
+// this file should not be edited - if changes are necessary, the generator should be updated, then this file should be re-created
+public class ScanFullResultItemsTransitiveUpgradeGuidanceLongTermUpgradeGuidanceVulnerabilityRiskView extends BlackDuckComponent {
+    private BigDecimal critical;
+    private BigDecimal high;
+    private BigDecimal low;
+    private BigDecimal medium;
+    private BigDecimal unscored;
+
+    public BigDecimal getCritical() {
+        return critical;
+    }
+
+    public void setCritical(BigDecimal critical) {
+        this.critical = critical;
+    }
+
+    public BigDecimal getHigh() {
+        return high;
+    }
+
+    public void setHigh(BigDecimal high) {
+        this.high = high;
+    }
+
+    public BigDecimal getLow() {
+        return low;
+    }
+
+    public void setLow(BigDecimal low) {
+        this.low = low;
+    }
+
+    public BigDecimal getMedium() {
+        return medium;
+    }
+
+    public void setMedium(BigDecimal medium) {
+        this.medium = medium;
+    }
+
+    public BigDecimal getUnscored() {
+        return unscored;
+    }
+
+    public void setUnscored(BigDecimal unscored) {
+        this.unscored = unscored;
+    }
+
+}

--- a/src/main/java/com/synopsys/integration/blackduck/api/generated/component/ScanFullResultItemsTransitiveUpgradeGuidanceShortTermUpgradeGuidanceView.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/generated/component/ScanFullResultItemsTransitiveUpgradeGuidanceShortTermUpgradeGuidanceView.java
@@ -1,0 +1,34 @@
+/*
+ * blackduck-common-api
+ *
+ * Copyright (c) 2023 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
+package com.synopsys.integration.blackduck.api.generated.component;
+
+import com.synopsys.integration.blackduck.api.core.BlackDuckComponent;
+import com.synopsys.integration.blackduck.api.generated.component.ScanFullResultItemsTransitiveUpgradeGuidanceShortTermUpgradeGuidanceVulnerabilityRiskView;
+
+// this file should not be edited - if changes are necessary, the generator should be updated, then this file should be re-created
+public class ScanFullResultItemsTransitiveUpgradeGuidanceShortTermUpgradeGuidanceView extends BlackDuckComponent {
+    private String versionName;
+    private ScanFullResultItemsTransitiveUpgradeGuidanceShortTermUpgradeGuidanceVulnerabilityRiskView vulnerabilityRisk;
+
+    public String getVersionName() {
+        return versionName;
+    }
+
+    public void setVersionName(String versionName) {
+        this.versionName = versionName;
+    }
+
+    public ScanFullResultItemsTransitiveUpgradeGuidanceShortTermUpgradeGuidanceVulnerabilityRiskView getVulnerabilityRisk() {
+        return vulnerabilityRisk;
+    }
+
+    public void setVulnerabilityRisk(ScanFullResultItemsTransitiveUpgradeGuidanceShortTermUpgradeGuidanceVulnerabilityRiskView vulnerabilityRisk) {
+        this.vulnerabilityRisk = vulnerabilityRisk;
+    }
+
+}

--- a/src/main/java/com/synopsys/integration/blackduck/api/generated/component/ScanFullResultItemsTransitiveUpgradeGuidanceShortTermUpgradeGuidanceVulnerabilityRiskView.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/generated/component/ScanFullResultItemsTransitiveUpgradeGuidanceShortTermUpgradeGuidanceVulnerabilityRiskView.java
@@ -1,0 +1,61 @@
+/*
+ * blackduck-common-api
+ *
+ * Copyright (c) 2023 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
+package com.synopsys.integration.blackduck.api.generated.component;
+
+import java.math.BigDecimal;
+import com.synopsys.integration.blackduck.api.core.BlackDuckComponent;
+
+// this file should not be edited - if changes are necessary, the generator should be updated, then this file should be re-created
+public class ScanFullResultItemsTransitiveUpgradeGuidanceShortTermUpgradeGuidanceVulnerabilityRiskView extends BlackDuckComponent {
+    private BigDecimal critical;
+    private BigDecimal high;
+    private BigDecimal low;
+    private BigDecimal medium;
+    private BigDecimal unscored;
+
+    public BigDecimal getCritical() {
+        return critical;
+    }
+
+    public void setCritical(BigDecimal critical) {
+        this.critical = critical;
+    }
+
+    public BigDecimal getHigh() {
+        return high;
+    }
+
+    public void setHigh(BigDecimal high) {
+        this.high = high;
+    }
+
+    public BigDecimal getLow() {
+        return low;
+    }
+
+    public void setLow(BigDecimal low) {
+        this.low = low;
+    }
+
+    public BigDecimal getMedium() {
+        return medium;
+    }
+
+    public void setMedium(BigDecimal medium) {
+        this.medium = medium;
+    }
+
+    public BigDecimal getUnscored() {
+        return unscored;
+    }
+
+    public void setUnscored(BigDecimal unscored) {
+        this.unscored = unscored;
+    }
+
+}

--- a/src/main/java/com/synopsys/integration/blackduck/api/generated/component/ScanFullResultItemsTransitiveUpgradeGuidanceView.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/generated/component/ScanFullResultItemsTransitiveUpgradeGuidanceView.java
@@ -1,0 +1,44 @@
+/*
+ * blackduck-common-api
+ *
+ * Copyright (c) 2023 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
+package com.synopsys.integration.blackduck.api.generated.component;
+
+import com.synopsys.integration.blackduck.api.core.BlackDuckComponent;
+import com.synopsys.integration.blackduck.api.generated.component.ScanFullResultItemsTransitiveUpgradeGuidanceLongTermUpgradeGuidanceView;
+import com.synopsys.integration.blackduck.api.generated.component.ScanFullResultItemsTransitiveUpgradeGuidanceShortTermUpgradeGuidanceView;
+
+// this file should not be edited - if changes are necessary, the generator should be updated, then this file should be re-created
+public class ScanFullResultItemsTransitiveUpgradeGuidanceView extends BlackDuckComponent {
+    private String externalId;
+    private ScanFullResultItemsTransitiveUpgradeGuidanceLongTermUpgradeGuidanceView longTermUpgradeGuidance;
+    private ScanFullResultItemsTransitiveUpgradeGuidanceShortTermUpgradeGuidanceView shortTermUpgradeGuidance;
+
+    public String getExternalId() {
+        return externalId;
+    }
+
+    public void setExternalId(String externalId) {
+        this.externalId = externalId;
+    }
+
+    public ScanFullResultItemsTransitiveUpgradeGuidanceLongTermUpgradeGuidanceView getLongTermUpgradeGuidance() {
+        return longTermUpgradeGuidance;
+    }
+
+    public void setLongTermUpgradeGuidance(ScanFullResultItemsTransitiveUpgradeGuidanceLongTermUpgradeGuidanceView longTermUpgradeGuidance) {
+        this.longTermUpgradeGuidance = longTermUpgradeGuidance;
+    }
+
+    public ScanFullResultItemsTransitiveUpgradeGuidanceShortTermUpgradeGuidanceView getShortTermUpgradeGuidance() {
+        return shortTermUpgradeGuidance;
+    }
+
+    public void setShortTermUpgradeGuidance(ScanFullResultItemsTransitiveUpgradeGuidanceShortTermUpgradeGuidanceView shortTermUpgradeGuidance) {
+        this.shortTermUpgradeGuidance = shortTermUpgradeGuidance;
+    }
+
+}

--- a/src/main/java/com/synopsys/integration/blackduck/api/generated/component/SettingsDataRetentionView.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/generated/component/SettingsDataRetentionView.java
@@ -12,7 +12,43 @@ import com.synopsys.integration.blackduck.api.core.BlackDuckComponent;
 
 // this file should not be edited - if changes are necessary, the generator should be updated, then this file should be re-created
 public class SettingsDataRetentionView extends BlackDuckComponent {
+    private BigDecimal autoRemovalGraceDays;
+    private java.util.List<String> autoRemovalPhaseSet;
+    private BigDecimal autoRemovalRetentionDays;
+    private Boolean enableAutoRemoval;
     private BigDecimal unmappedCodeLocationRetentionDays;
+
+    public BigDecimal getAutoRemovalGraceDays() {
+        return autoRemovalGraceDays;
+    }
+
+    public void setAutoRemovalGraceDays(BigDecimal autoRemovalGraceDays) {
+        this.autoRemovalGraceDays = autoRemovalGraceDays;
+    }
+
+    public java.util.List<String> getAutoRemovalPhaseSet() {
+        return autoRemovalPhaseSet;
+    }
+
+    public void setAutoRemovalPhaseSet(java.util.List<String> autoRemovalPhaseSet) {
+        this.autoRemovalPhaseSet = autoRemovalPhaseSet;
+    }
+
+    public BigDecimal getAutoRemovalRetentionDays() {
+        return autoRemovalRetentionDays;
+    }
+
+    public void setAutoRemovalRetentionDays(BigDecimal autoRemovalRetentionDays) {
+        this.autoRemovalRetentionDays = autoRemovalRetentionDays;
+    }
+
+    public Boolean getEnableAutoRemoval() {
+        return enableAutoRemoval;
+    }
+
+    public void setEnableAutoRemoval(Boolean enableAutoRemoval) {
+        this.enableAutoRemoval = enableAutoRemoval;
+    }
 
     public BigDecimal getUnmappedCodeLocationRetentionDays() {
         return unmappedCodeLocationRetentionDays;

--- a/src/main/java/com/synopsys/integration/blackduck/api/generated/component/SettingsUnmatchedFileRetentionView.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/generated/component/SettingsUnmatchedFileRetentionView.java
@@ -11,14 +11,14 @@ import com.synopsys.integration.blackduck.api.core.BlackDuckComponent;
 
 // this file should not be edited - if changes are necessary, the generator should be updated, then this file should be re-created
 public class SettingsUnmatchedFileRetentionView extends BlackDuckComponent {
-    private Boolean purgeUnmatchedFilesEnabled;
+    private String purgeUnmatchedFilesEnabled;
     private Boolean unmatchedFileRetentionEnabled;
 
-    public Boolean getPurgeUnmatchedFilesEnabled() {
+    public String getPurgeUnmatchedFilesEnabled() {
         return purgeUnmatchedFilesEnabled;
     }
 
-    public void setPurgeUnmatchedFilesEnabled(Boolean purgeUnmatchedFilesEnabled) {
+    public void setPurgeUnmatchedFilesEnabled(String purgeUnmatchedFilesEnabled) {
         this.purgeUnmatchedFilesEnabled = purgeUnmatchedFilesEnabled;
     }
 

--- a/src/main/java/com/synopsys/integration/blackduck/api/generated/component/Varies.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/generated/component/Varies.java
@@ -8,18 +8,8 @@
 package com.synopsys.integration.blackduck.api.generated.component;
 
 import com.synopsys.integration.blackduck.api.core.BlackDuckComponent;
-import com.synopsys.integration.blackduck.api.generated.component.FeaturesScm;
 
 // this file should not be edited - if changes are necessary, the generator should be updated, then this file should be re-created
-public class Features extends BlackDuckComponent {
-    private FeaturesScm scm;
-
-    public FeaturesScm getScm() {
-        return scm;
-    }
-
-    public void setScm(FeaturesScm scm) {
-        this.scm = scm;
-    }
+public class Varies extends BlackDuckComponent {
 
 }

--- a/src/main/java/com/synopsys/integration/blackduck/api/generated/deprecated/view/VulnerableComponentView.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/generated/deprecated/view/VulnerableComponentView.java
@@ -44,6 +44,7 @@ public class VulnerableComponentView extends BlackDuckView {
     private String componentVersionOriginName;
     private Boolean ignored;
     private ProjectVersionVulnerableBomComponentsItemsLicenseView license;
+    private String packageUrl;
     private ProjectVersionVulnerableBomComponentsItemsVulnerabilityWithRemediationView vulnerabilityWithRemediation;
 
     public String getComponentName() {
@@ -100,6 +101,14 @@ public class VulnerableComponentView extends BlackDuckView {
 
     public void setLicense(ProjectVersionVulnerableBomComponentsItemsLicenseView license) {
         this.license = license;
+    }
+
+    public String getPackageUrl() {
+        return packageUrl;
+    }
+
+    public void setPackageUrl(String packageUrl) {
+        this.packageUrl = packageUrl;
     }
 
     public ProjectVersionVulnerableBomComponentsItemsVulnerabilityWithRemediationView getVulnerabilityWithRemediation() {

--- a/src/main/java/com/synopsys/integration/blackduck/api/generated/discovery/ApiDiscovery.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/generated/discovery/ApiDiscovery.java
@@ -41,12 +41,15 @@ import com.synopsys.integration.blackduck.api.generated.view.PurgeTokensView;
 import com.synopsys.integration.blackduck.api.generated.view.RegistrationView;
 import com.synopsys.integration.blackduck.api.generated.view.ReportContentsView;
 import com.synopsys.integration.blackduck.api.generated.view.RoleView;
+import com.synopsys.integration.blackduck.api.generated.view.SbomFieldsScopesView;
+import com.synopsys.integration.blackduck.api.generated.view.ScanMonitorView;
 import com.synopsys.integration.blackduck.api.generated.view.ScanReadinessView;
 import com.synopsys.integration.blackduck.api.generated.view.ScanView;
 import com.synopsys.integration.blackduck.api.generated.view.SettingsAnalysisView;
 import com.synopsys.integration.blackduck.api.generated.view.SsoConfigurationView;
 import com.synopsys.integration.blackduck.api.generated.view.SystemOauthClientView;
 import com.synopsys.integration.blackduck.api.generated.view.TokensView;
+import com.synopsys.integration.blackduck.api.generated.view.ToolsView;
 import com.synopsys.integration.blackduck.api.generated.view.UserGroupView;
 import com.synopsys.integration.blackduck.api.generated.view.UserView;
 import com.synopsys.integration.blackduck.api.generated.view.VulnerabilityReportsReportView;
@@ -90,12 +93,15 @@ public class ApiDiscovery {
     public static final BlackDuckPath<RegistrationView> REGISTRATION_PATH = new BlackDuckPath("/api/registration", RegistrationView.class, false);
     public static final BlackDuckPath<ReportContentsView> REPORTS_PATH = new BlackDuckPath("/api/reports", ReportContentsView.class, false);
     public static final BlackDuckPath<RoleView> ROLES_PATH = new BlackDuckPath("/api/roles", RoleView.class, true);
+    public static final BlackDuckPath<SbomFieldsScopesView> SBOM_FIELDS_PATH = new BlackDuckPath("/api/sbom-fields", SbomFieldsScopesView.class, false);
+    public static final BlackDuckPath<ScanMonitorView> SCAN_MONITOR_PATH = new BlackDuckPath("/api/scan-monitor", ScanMonitorView.class, false);
     public static final BlackDuckPath<ScanReadinessView> SCAN_READINESS_PATH = new BlackDuckPath("/api/scan-readiness", ScanReadinessView.class, false);
     public static final BlackDuckPath<ScanView> SCAN_SUMMARIES_PATH = new BlackDuckPath("/api/scan-summaries", ScanView.class, false);
     public static final BlackDuckPath<SettingsAnalysisView> SETTINGS_PATH = new BlackDuckPath("/api/settings", SettingsAnalysisView.class, false);
     public static final BlackDuckPath<SsoConfigurationView> SSO_PATH = new BlackDuckPath("/api/sso", SsoConfigurationView.class, false);
     public static final BlackDuckPath<SystemOauthClientView> SYSTEM_OAUTH_CLIENT_PATH = new BlackDuckPath("/api/system-oauth-client", SystemOauthClientView.class, false);
     public static final BlackDuckPath<TokensView> TOKENS_PATH = new BlackDuckPath("/api/tokens", TokensView.class, false);
+    public static final BlackDuckPath<ToolsView> TOOLS_PATH = new BlackDuckPath("/api/tools", ToolsView.class, false);
     public static final BlackDuckPath<BlackDuckStringResponse> UPLOADS_PATH = new BlackDuckPath("/api/uploads", BlackDuckStringResponse.class, false);
     public static final BlackDuckPath<UserGroupView> USERGROUPS_PATH = new BlackDuckPath("/api/usergroups", UserGroupView.class, true);
     public static final BlackDuckPath<UserView> USERS_PATH = new BlackDuckPath("/api/users", UserView.class, true);
@@ -241,6 +247,14 @@ public class ApiDiscovery {
         return metaMultipleResponses(ROLES_PATH);
     }
 
+    public UrlSingleResponse<SbomFieldsScopesView> metaSbomFieldsLink() {
+        return metaSingleResponse(SBOM_FIELDS_PATH);
+    }
+
+    public UrlSingleResponse<ScanMonitorView> metaScanMonitorLink() {
+        return metaSingleResponse(SCAN_MONITOR_PATH);
+    }
+
     public UrlSingleResponse<ScanReadinessView> metaScanReadinessLink() {
         return metaSingleResponse(SCAN_READINESS_PATH);
     }
@@ -263,6 +277,10 @@ public class ApiDiscovery {
 
     public UrlSingleResponse<TokensView> metaTokensLink() {
         return metaSingleResponse(TOKENS_PATH);
+    }
+
+    public UrlSingleResponse<ToolsView> metaToolsLink() {
+        return metaSingleResponse(TOOLS_PATH);
     }
 
     public UrlSingleResponse<BlackDuckStringResponse> metaUploadsLink() {

--- a/src/main/java/com/synopsys/integration/blackduck/api/generated/discovery/BlackDuckMediaTypeDiscovery.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/generated/discovery/BlackDuckMediaTypeDiscovery.java
@@ -24,6 +24,7 @@ public class BlackDuckMediaTypeDiscovery {
     public static final Set<String> VALUES_TO_REPLACE = new HashSet<>(Arrays.asList(null, DEFAULT_MEDIA_TYPE));
 
     public static final String VND_BLACKDUCKSOFTWARE_ADMIN_4_JSON = "application/vnd.blackducksoftware.admin-4+json";
+    public static final String VND_BLACKDUCKSOFTWARE_ADMIN_5_JSON = "application/vnd.blackducksoftware.admin-5+json";
     public static final String VND_BLACKDUCKSOFTWARE_BILL_OF_MATERIALS_6_JSON = "application/vnd.blackducksoftware.bill-of-materials-6+json";
     public static final String VND_BLACKDUCKSOFTWARE_COMPONENT_DETAIL_4_JSON = "application/vnd.blackducksoftware.component-detail-4+json";
     public static final String VND_BLACKDUCKSOFTWARE_COMPONENT_DETAIL_5_JSON = "application/vnd.blackducksoftware.component-detail-5+json";
@@ -34,13 +35,16 @@ public class BlackDuckMediaTypeDiscovery {
     public static final String VND_BLACKDUCKSOFTWARE_POLICY_5_JSON = "application/vnd.blackducksoftware.policy-5+json";
     public static final String VND_BLACKDUCKSOFTWARE_PROJECT_DETAIL_4_JSON = "application/vnd.blackducksoftware.project-detail-4+json";
     public static final String VND_BLACKDUCKSOFTWARE_PROJECT_DETAIL_5_JSON = "application/vnd.blackducksoftware.project-detail-5+json";
+    public static final String VND_BLACKDUCKSOFTWARE_PROJECT_DETAIL_6_JSON = "application/vnd.blackducksoftware.project-detail-6+json";
     public static final String VND_BLACKDUCKSOFTWARE_REPORT_4_JSON = "application/vnd.blackducksoftware.report-4+json";
     public static final String VND_BLACKDUCKSOFTWARE_SCAN_4_JSON = "application/vnd.blackducksoftware.scan-4+json";
     public static final String VND_BLACKDUCKSOFTWARE_SCAN_6_JSON = "application/vnd.blackducksoftware.scan-6+json";
+    public static final String VND_BLACKDUCKSOFTWARE_SCAN_MONITOR_1_JSON = "application/vnd.blackducksoftware.scan-monitor-1+json";
     public static final String VND_BLACKDUCKSOFTWARE_SCAN_READINESS_1_JSON = "application/vnd.blackducksoftware.scan-readiness-1+json";
     public static final String VND_BLACKDUCKSOFTWARE_SOURCE_VIEW_1_JSON = "application/vnd.blackducksoftware.source-view-1+json";
     public static final String VND_BLACKDUCKSOFTWARE_STATUS_4_JSON = "application/vnd.blackducksoftware.status-4+json";
     public static final String VND_BLACKDUCKSOFTWARE_SYSTEM_ANNOUNCEMENT_1_JSON = "application/vnd.blackducksoftware.system-announcement-1+json";
+    public static final String VND_BLACKDUCKSOFTWARE_TOOL_VIEW_1_JSON = "application/vnd.blackducksoftware.tool-view-1+json";
     public static final String VND_BLACKDUCKSOFTWARE_USER_4_JSON = "application/vnd.blackducksoftware.user-4+json";
     public static final String VND_BLACKDUCKSOFTWARE_VULNERABILITY_4_JSON = "application/vnd.blackducksoftware.vulnerability-4+json";
     public static final String TEXT_PLAIN = "text/plain";
@@ -73,6 +77,7 @@ public class BlackDuckMediaTypeDiscovery {
     public static final String API_COMPONENTS_VERSIONS_ORIGIN_FILE_LICENSES_WITH_ID = String.format("/api/components/%s/versions/%s/origin/%s/file-licenses/%s", UUID_REGEX, UUID_REGEX, UUID_REGEX, UUID_REGEX);
     public static final String API_COMPONENTS_VERSIONS_ORIGINS_WITH_ID = String.format("/api/components/%s/versions/%s/origins/%s", UUID_REGEX, UUID_REGEX, UUID_REGEX);
     public static final String API_COMPONENTS_VERSIONS_ORIGINS_COPYRIGHTS = String.format("/api/components/%s/versions/%s/origins/%s/copyrights", UUID_REGEX, UUID_REGEX, UUID_REGEX);
+    public static final String API_COMPONENTS_VERSIONS_ORIGINS_TRANSITIVE_UPGRADE_GUIDANCE = String.format("/api/components/%s/versions/%s/origins/%s/transitive-upgrade-guidance", UUID_REGEX, UUID_REGEX, UUID_REGEX);
     public static final String API_COMPONENTS_VERSIONS_ORIGINS_UPGRADE_GUIDANCE = String.format("/api/components/%s/versions/%s/origins/%s/upgrade-guidance", UUID_REGEX, UUID_REGEX, UUID_REGEX);
     public static final String API_COMPONENTS_VERSIONS_RISK_PROFILE = String.format("/api/components/%s/versions/%s/risk-profile", UUID_REGEX, UUID_REGEX);
     public static final String API_COMPONENTS_VERSIONS_UPGRADE_GUIDANCE = String.format("/api/components/%s/versions/%s/upgrade-guidance", UUID_REGEX, UUID_REGEX);
@@ -127,6 +132,7 @@ public class BlackDuckMediaTypeDiscovery {
     public static final String API_PROJECT_GROUPS_HIERARCHY = String.format("/api/project-groups/%s/hierarchy", UUID_REGEX);
     public static final String API_PROJECT_GROUPS_POSSIBLE_CHILD_PROJECT_GROUPS = String.format("/api/project-groups/%s/possible-child-project-groups", UUID_REGEX);
     public static final String API_PROJECT_GROUPS_PROJECT_GROUPS = String.format("/api/project-groups/%s/project-groups", UUID_REGEX);
+    public static final String API_PROJECT_GROUPS_SBOM_FIELDS = String.format("/api/project-groups/%s/sbom-fields", UUID_REGEX);
     public static final String API_PROJECT_GROUPS_USERGROUPS_WITH_ID = String.format("/api/project-groups/%s/usergroups/%s", UUID_REGEX, UUID_REGEX);
     public static final String API_PROJECT_GROUPS_USERS_WITH_ID = String.format("/api/project-groups/%s/users/%s", UUID_REGEX, UUID_REGEX);
     public static final String API_PROJECT_VERSION_ORIGIN_DEPENDENCY_PATHS = String.format("/api/project/%s/version/%s/origin/%s/dependency-paths", UUID_REGEX, UUID_REGEX, UUID_REGEX);
@@ -140,7 +146,6 @@ public class BlackDuckMediaTypeDiscovery {
     public static final String API_PROJECTS_VERSIONS_WITH_ID = String.format("/api/projects/%s/versions/%s", UUID_REGEX, UUID_REGEX);
     public static final String API_PROJECTS_VERSIONS_BOM_EVENTS = String.format("/api/projects/%s/versions/%s/bom-events", UUID_REGEX, UUID_REGEX);
     public static final String API_PROJECTS_VERSIONS_BOM_STATUS = String.format("/api/projects/%s/versions/%s/bom-status", UUID_REGEX, UUID_REGEX);
-    public static final String API_PROJECTS_VERSIONS_BOM_STATUS_WITH_ID = String.format("/api/projects/%s/versions/%s/bom-status/%s", UUID_REGEX, UUID_REGEX, UUID_REGEX);
     public static final String API_PROJECTS_VERSIONS_CODE_LOCATIONS = String.format("/api/projects/%s/versions/%s/code-locations", UUID_REGEX, UUID_REGEX);
     public static final String API_PROJECTS_VERSIONS_COMPARISON = String.format("/api/projects/%s/versions/%s/comparison", UUID_REGEX, UUID_REGEX);
     public static final String API_PROJECTS_VERSIONS_COMPONENTS_WITH_ID = String.format("/api/projects/%s/versions/%s/components/%s", UUID_REGEX, UUID_REGEX, UUID_REGEX);
@@ -182,6 +187,7 @@ public class BlackDuckMediaTypeDiscovery {
     public static final String API_ROLES_WITH_ID = String.format("/api/roles/%s", UUID_REGEX);
     public static final String API_SBOM_FIELDS_SCOPES = String.format("/api/sbom-fields/scopes");
     public static final String API_SBOM_FIELDS_SCOPES_SCOPE_FIELDS = String.format("/api/sbom-fields/scopes/scope/fields");
+    public static final String API_SCAN_MONITOR = String.format("/api/scan-monitor");
     public static final String API_SCAN_READINESS = String.format("/api/scan-readiness");
     public static final String API_SCAN_SUMMARIES_WITH_ID = String.format("/api/scan-summaries/%s", UUID_REGEX);
     public static final String API_SETTINGS_ANALYSIS = String.format("/api/settings/analysis");
@@ -198,6 +204,7 @@ public class BlackDuckMediaTypeDiscovery {
     public static final String API_SYSTEM_OAUTH_CLIENT = String.format("/api/system-oauth-client");
     public static final String API_TOKENS = String.format("/api/tokens");
     public static final String API_TOKENS_WITH_ID = String.format("/api/tokens/%s", UUID_REGEX);
+    public static final String API_TOOLS = String.format("/api/tools");
     public static final String API_USERGROUPS_WITH_ID = String.format("/api/usergroups/%s", UUID_REGEX);
     public static final String API_USERGROUPS_ASSIGNABLE_PROJECT_GROUPS = String.format("/api/usergroups/%s/assignable-project-groups", UUID_REGEX);
     public static final String API_USERGROUPS_ASSIGNABLE_PROJECTS = String.format("/api/usergroups/%s/assignable-projects", UUID_REGEX);
@@ -253,6 +260,7 @@ public class BlackDuckMediaTypeDiscovery {
         mediaTypeMatchers.add(new MediaTypeMatcher(API_COMPONENTS_VERSIONS_LICENSES_TEXT, TEXT_PLAIN));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_COMPONENTS_VERSIONS_LICENSES_WITH_ID, VND_BLACKDUCKSOFTWARE_COMPONENT_DETAIL_5_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_COMPONENTS_VERSIONS_ORIGINS_COPYRIGHTS, VND_BLACKDUCKSOFTWARE_COPYRIGHT_4_JSON));
+        mediaTypeMatchers.add(new MediaTypeMatcher(API_COMPONENTS_VERSIONS_ORIGINS_TRANSITIVE_UPGRADE_GUIDANCE, VND_BLACKDUCKSOFTWARE_COMPONENT_DETAIL_5_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_COMPONENTS_VERSIONS_ORIGINS_UPGRADE_GUIDANCE, VND_BLACKDUCKSOFTWARE_COMPONENT_DETAIL_5_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_COMPONENTS_VERSIONS_ORIGINS_WITH_ID, VND_BLACKDUCKSOFTWARE_COMPONENT_DETAIL_5_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_COMPONENTS_VERSIONS_ORIGIN_FILE_COPYRIGHTS, VND_BLACKDUCKSOFTWARE_COMPONENT_DETAIL_5_JSON));
@@ -315,7 +323,6 @@ public class BlackDuckMediaTypeDiscovery {
         mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECTS_USERS_WITH_ID, VND_BLACKDUCKSOFTWARE_PROJECT_DETAIL_4_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECTS_VERSIONS_BOM_EVENTS, VND_BLACKDUCKSOFTWARE_BILL_OF_MATERIALS_6_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECTS_VERSIONS_BOM_STATUS, VND_BLACKDUCKSOFTWARE_BILL_OF_MATERIALS_6_JSON));
-        mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECTS_VERSIONS_BOM_STATUS_WITH_ID, VND_BLACKDUCKSOFTWARE_BILL_OF_MATERIALS_6_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECTS_VERSIONS_CODE_LOCATIONS, VND_BLACKDUCKSOFTWARE_INTERNAL_1_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECTS_VERSIONS_COMPARISON, VND_BLACKDUCKSOFTWARE_BILL_OF_MATERIALS_6_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECTS_VERSIONS_COMPONENTS_COMMENTS_WITH_ID, VND_BLACKDUCKSOFTWARE_BILL_OF_MATERIALS_6_JSON));
@@ -351,7 +358,7 @@ public class BlackDuckMediaTypeDiscovery {
         mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECTS_VERSIONS_VULNERABILITIES_VULNERABILITY_MATCHES, VND_BLACKDUCKSOFTWARE_VULNERABILITY_4_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECTS_VERSIONS_VULNERABLE_BOM_COMPONENTS, VND_BLACKDUCKSOFTWARE_BILL_OF_MATERIALS_6_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECTS_VERSIONS_WITH_ID, VND_BLACKDUCKSOFTWARE_PROJECT_DETAIL_5_JSON));
-        mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECTS_WITH_ID, VND_BLACKDUCKSOFTWARE_PROJECT_DETAIL_4_JSON));
+        mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECTS_WITH_ID, VND_BLACKDUCKSOFTWARE_PROJECT_DETAIL_5_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECT_GROUPS, VND_BLACKDUCKSOFTWARE_PROJECT_DETAIL_5_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECT_GROUPS_CHILDREN, VND_BLACKDUCKSOFTWARE_PROJECT_DETAIL_5_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECT_GROUPS_DESCENDANTS, VND_BLACKDUCKSOFTWARE_PROJECT_DETAIL_5_JSON));
@@ -359,6 +366,7 @@ public class BlackDuckMediaTypeDiscovery {
         mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECT_GROUPS_HIERARCHY, VND_BLACKDUCKSOFTWARE_PROJECT_DETAIL_5_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECT_GROUPS_POSSIBLE_CHILD_PROJECT_GROUPS, VND_BLACKDUCKSOFTWARE_PROJECT_DETAIL_5_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECT_GROUPS_PROJECT_GROUPS, VND_BLACKDUCKSOFTWARE_PROJECT_DETAIL_5_JSON));
+        mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECT_GROUPS_SBOM_FIELDS, VND_BLACKDUCKSOFTWARE_PROJECT_DETAIL_5_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECT_GROUPS_USERGROUPS_WITH_ID, VND_BLACKDUCKSOFTWARE_PROJECT_DETAIL_5_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECT_GROUPS_USERS_WITH_ID, VND_BLACKDUCKSOFTWARE_PROJECT_DETAIL_5_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECT_GROUPS_WITH_ID, VND_BLACKDUCKSOFTWARE_PROJECT_DETAIL_5_JSON));
@@ -370,22 +378,24 @@ public class BlackDuckMediaTypeDiscovery {
         mediaTypeMatchers.add(new MediaTypeMatcher(API_ROLES_WITH_ID, VND_BLACKDUCKSOFTWARE_USER_4_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_SBOM_FIELDS_SCOPES, VND_BLACKDUCKSOFTWARE_BILL_OF_MATERIALS_6_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_SBOM_FIELDS_SCOPES_SCOPE_FIELDS, VND_BLACKDUCKSOFTWARE_BILL_OF_MATERIALS_6_JSON));
+        mediaTypeMatchers.add(new MediaTypeMatcher(API_SCAN_MONITOR, VND_BLACKDUCKSOFTWARE_SCAN_MONITOR_1_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_SCAN_READINESS, VND_BLACKDUCKSOFTWARE_SCAN_READINESS_1_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_SCAN_SUMMARIES_WITH_ID, VND_BLACKDUCKSOFTWARE_SCAN_6_JSON));
-        mediaTypeMatchers.add(new MediaTypeMatcher(API_SETTINGS_ANALYSIS, VND_BLACKDUCKSOFTWARE_ADMIN_4_JSON));
-        mediaTypeMatchers.add(new MediaTypeMatcher(API_SETTINGS_API_TOKEN_PURGE, VND_BLACKDUCKSOFTWARE_ADMIN_4_JSON));
-        mediaTypeMatchers.add(new MediaTypeMatcher(API_SETTINGS_AUTO_REMEDIATE_UNMAPPED, VND_BLACKDUCKSOFTWARE_ADMIN_4_JSON));
-        mediaTypeMatchers.add(new MediaTypeMatcher(API_SETTINGS_BRANDING, VND_BLACKDUCKSOFTWARE_ADMIN_4_JSON));
-        mediaTypeMatchers.add(new MediaTypeMatcher(API_SETTINGS_CUSTOM_FIELDS, VND_BLACKDUCKSOFTWARE_ADMIN_4_JSON));
-        mediaTypeMatchers.add(new MediaTypeMatcher(API_SETTINGS_DATA_RETENTION, VND_BLACKDUCKSOFTWARE_ADMIN_4_JSON));
-        mediaTypeMatchers.add(new MediaTypeMatcher(API_SETTINGS_LICENSE_REVIEW, VND_BLACKDUCKSOFTWARE_ADMIN_4_JSON));
-        mediaTypeMatchers.add(new MediaTypeMatcher(API_SETTINGS_ROLE, VND_BLACKDUCKSOFTWARE_ADMIN_4_JSON));
-        mediaTypeMatchers.add(new MediaTypeMatcher(API_SETTINGS_UNMATCHED_FILE_RETENTION, VND_BLACKDUCKSOFTWARE_ADMIN_4_JSON));
+        mediaTypeMatchers.add(new MediaTypeMatcher(API_SETTINGS_ANALYSIS, VND_BLACKDUCKSOFTWARE_ADMIN_5_JSON));
+        mediaTypeMatchers.add(new MediaTypeMatcher(API_SETTINGS_API_TOKEN_PURGE, VND_BLACKDUCKSOFTWARE_ADMIN_5_JSON));
+        mediaTypeMatchers.add(new MediaTypeMatcher(API_SETTINGS_AUTO_REMEDIATE_UNMAPPED, VND_BLACKDUCKSOFTWARE_ADMIN_5_JSON));
+        mediaTypeMatchers.add(new MediaTypeMatcher(API_SETTINGS_BRANDING, VND_BLACKDUCKSOFTWARE_ADMIN_5_JSON));
+        mediaTypeMatchers.add(new MediaTypeMatcher(API_SETTINGS_CUSTOM_FIELDS, VND_BLACKDUCKSOFTWARE_ADMIN_5_JSON));
+        mediaTypeMatchers.add(new MediaTypeMatcher(API_SETTINGS_DATA_RETENTION, VND_BLACKDUCKSOFTWARE_ADMIN_5_JSON));
+        mediaTypeMatchers.add(new MediaTypeMatcher(API_SETTINGS_LICENSE_REVIEW, VND_BLACKDUCKSOFTWARE_ADMIN_5_JSON));
+        mediaTypeMatchers.add(new MediaTypeMatcher(API_SETTINGS_ROLE, VND_BLACKDUCKSOFTWARE_ADMIN_5_JSON));
+        mediaTypeMatchers.add(new MediaTypeMatcher(API_SETTINGS_UNMATCHED_FILE_RETENTION, VND_BLACKDUCKSOFTWARE_ADMIN_5_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_SSO_CONFIGURATION, VND_BLACKDUCKSOFTWARE_ADMIN_4_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_SSO_STATUS, VND_BLACKDUCKSOFTWARE_ADMIN_4_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_SYSTEM_OAUTH_CLIENT, VND_BLACKDUCKSOFTWARE_USER_4_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_TOKENS, VND_BLACKDUCKSOFTWARE_USER_4_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_TOKENS_WITH_ID, VND_BLACKDUCKSOFTWARE_USER_4_JSON));
+        mediaTypeMatchers.add(new MediaTypeMatcher(API_TOOLS, VND_BLACKDUCKSOFTWARE_TOOL_VIEW_1_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_USERGROUPS_ASSIGNABLE_PROJECTS, VND_BLACKDUCKSOFTWARE_USER_4_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_USERGROUPS_ASSIGNABLE_PROJECT_GROUPS, VND_BLACKDUCKSOFTWARE_USER_4_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_USERGROUPS_PROJECTS, VND_BLACKDUCKSOFTWARE_PROJECT_DETAIL_4_JSON));

--- a/src/main/java/com/synopsys/integration/blackduck/api/generated/enumeration/ComponentVersionSbomFieldsItemsValueType.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/generated/enumeration/ComponentVersionSbomFieldsItemsValueType.java
@@ -1,0 +1,21 @@
+/*
+ * blackduck-common-api
+ *
+ * Copyright (c) 2023 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
+package com.synopsys.integration.blackduck.api.generated.enumeration;
+
+import com.synopsys.integration.util.EnumUtils;
+
+// this file should not be edited - if changes are necessary, the generator should be updated, then this file should be re-created
+public enum ComponentVersionSbomFieldsItemsValueType {
+    organization,
+	person;
+
+    public String prettyPrint() {
+        return EnumUtils.prettyPrint(this);
+    }
+
+}

--- a/src/main/java/com/synopsys/integration/blackduck/api/generated/enumeration/ProjectVersionMatchedFilesItemsMatchesMatchTypeFilterValueType.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/generated/enumeration/ProjectVersionMatchedFilesItemsMatchesMatchTypeFilterValueType.java
@@ -1,0 +1,35 @@
+/*
+ * blackduck-common-api
+ *
+ * Copyright (c) 2023 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
+package com.synopsys.integration.blackduck.api.generated.enumeration;
+
+import com.synopsys.integration.util.EnumUtils;
+
+// this file should not be edited - if changes are necessary, the generator should be updated, then this file should be re-created
+public enum ProjectVersionMatchedFilesItemsMatchesMatchTypeFilterValueType {
+    BINARY,
+	BINARY_DIRECT_DEPENDENCY,
+	BINARY_TRANSITIVE_DEPENDENCY,
+	FILES_ADDED_DELETED,
+	FILES_EXACT,
+	FILES_MODIFIED,
+	FILE_DEPENDENCY,
+	FILE_DEPENDENCY_DIRECT,
+	FILE_DEPENDENCY_TRANSITIVE,
+	FILE_EXACT,
+	MANUALLY_ADDED,
+	MANUALLY_IDENTIFIED,
+	MANUAL_BOM_PACKAGE,
+	PARTIAL,
+	SNIPPET,
+	UNMATCHED;
+
+    public String prettyPrint() {
+        return EnumUtils.prettyPrint(this);
+    }
+
+}

--- a/src/main/java/com/synopsys/integration/blackduck/api/generated/enumeration/SbomFieldsScopesItemsScopeNameType.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/generated/enumeration/SbomFieldsScopesItemsScopeNameType.java
@@ -1,0 +1,22 @@
+/*
+ * blackduck-common-api
+ *
+ * Copyright (c) 2023 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
+package com.synopsys.integration.blackduck.api.generated.enumeration;
+
+import com.synopsys.integration.util.EnumUtils;
+
+// this file should not be edited - if changes are necessary, the generator should be updated, then this file should be re-created
+public enum SbomFieldsScopesItemsScopeNameType {
+    bom_component,
+	component,
+	project_group;
+
+    public String prettyPrint() {
+        return EnumUtils.prettyPrint(this);
+    }
+
+}

--- a/src/main/java/com/synopsys/integration/blackduck/api/generated/view/DeveloperScansScanView.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/generated/view/DeveloperScansScanView.java
@@ -16,6 +16,7 @@ import com.synopsys.integration.blackduck.api.generated.component.DeveloperScans
 import com.synopsys.integration.blackduck.api.generated.component.DeveloperScansScanItemsPolicyViolationLicensesView;
 import com.synopsys.integration.blackduck.api.generated.component.DeveloperScansScanItemsPolicyViolationVulnerabilitiesView;
 import com.synopsys.integration.blackduck.api.generated.component.DeveloperScansScanItemsShortTermUpgradeGuidanceView;
+import com.synopsys.integration.blackduck.api.generated.component.DeveloperScansScanItemsTransitiveUpgradeGuidanceView;
 import com.synopsys.integration.blackduck.api.generated.component.DeveloperScansScanItemsViolatingPoliciesView;
 
 // this file should not be edited - if changes are necessary, the generator should be updated, then this file should be re-created
@@ -34,6 +35,7 @@ public class DeveloperScansScanView extends BlackDuckView {
     private java.util.List<DeveloperScansScanItemsPolicyViolationLicensesView> policyViolationLicenses;
     private java.util.List<DeveloperScansScanItemsPolicyViolationVulnerabilitiesView> policyViolationVulnerabilities;
     private DeveloperScansScanItemsShortTermUpgradeGuidanceView shortTermUpgradeGuidance;
+    private java.util.List<DeveloperScansScanItemsTransitiveUpgradeGuidanceView> transitiveUpgradeGuidance;
     private String versionName;
     private java.util.List<DeveloperScansScanItemsViolatingPoliciesView> violatingPolicies;
 
@@ -147,6 +149,14 @@ public class DeveloperScansScanView extends BlackDuckView {
 
     public void setShortTermUpgradeGuidance(DeveloperScansScanItemsShortTermUpgradeGuidanceView shortTermUpgradeGuidance) {
         this.shortTermUpgradeGuidance = shortTermUpgradeGuidance;
+    }
+
+    public java.util.List<DeveloperScansScanItemsTransitiveUpgradeGuidanceView> getTransitiveUpgradeGuidance() {
+        return transitiveUpgradeGuidance;
+    }
+
+    public void setTransitiveUpgradeGuidance(java.util.List<DeveloperScansScanItemsTransitiveUpgradeGuidanceView> transitiveUpgradeGuidance) {
+        this.transitiveUpgradeGuidance = transitiveUpgradeGuidance;
     }
 
     public String getVersionName() {

--- a/src/main/java/com/synopsys/integration/blackduck/api/generated/view/JobView.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/generated/view/JobView.java
@@ -16,6 +16,7 @@ import com.synopsys.integration.blackduck.api.generated.enumeration.JobStatusTyp
 public class JobView extends BlackDuckView {
     private String errorText;
     private java.util.Date finishedAt;
+    private String jobEntityDescription;
     private String progressData;
     private java.util.Date scheduledAt;
     private java.util.Date startedAt;
@@ -37,6 +38,14 @@ public class JobView extends BlackDuckView {
 
     public void setFinishedAt(java.util.Date finishedAt) {
         this.finishedAt = finishedAt;
+    }
+
+    public String getJobEntityDescription() {
+        return jobEntityDescription;
+    }
+
+    public void setJobEntityDescription(String jobEntityDescription) {
+        this.jobEntityDescription = jobEntityDescription;
     }
 
     public String getProgressData() {

--- a/src/main/java/com/synopsys/integration/blackduck/api/generated/view/ProjectVersionVulnerableBomComponentsView.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/generated/view/ProjectVersionVulnerableBomComponentsView.java
@@ -42,6 +42,7 @@ public class ProjectVersionVulnerableBomComponentsView extends BlackDuckView {
     private String componentVersionOriginName;
     private Boolean ignored;
     private ProjectVersionVulnerableBomComponentsItemsLicenseView license;
+    private String packageUrl;
     private ProjectVersionVulnerableBomComponentsItemsVulnerabilityWithRemediationView vulnerabilityWithRemediation;
 
     public String getComponentName() {
@@ -98,6 +99,14 @@ public class ProjectVersionVulnerableBomComponentsView extends BlackDuckView {
 
     public void setLicense(ProjectVersionVulnerableBomComponentsItemsLicenseView license) {
         this.license = license;
+    }
+
+    public String getPackageUrl() {
+        return packageUrl;
+    }
+
+    public void setPackageUrl(String packageUrl) {
+        this.packageUrl = packageUrl;
     }
 
     public ProjectVersionVulnerableBomComponentsItemsVulnerabilityWithRemediationView getVulnerabilityWithRemediation() {

--- a/src/main/java/com/synopsys/integration/blackduck/api/generated/view/ProjectView.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/generated/view/ProjectView.java
@@ -11,12 +11,14 @@ import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import com.synopsys.integration.blackduck.api.core.BlackDuckComponent;
 import com.synopsys.integration.blackduck.api.core.BlackDuckView;
 import com.synopsys.integration.blackduck.api.core.response.LinkBlackDuckResponse;
 import com.synopsys.integration.blackduck.api.core.response.LinkMultipleResponses;
 import com.synopsys.integration.blackduck.api.core.response.LinkSingleResponse;
 import com.synopsys.integration.blackduck.api.core.response.UrlMultipleResponses;
 import com.synopsys.integration.blackduck.api.core.response.UrlSingleResponse;
+import com.synopsys.integration.blackduck.api.generated.component.Varies;
 import com.synopsys.integration.blackduck.api.generated.enumeration.ProjectCloneCategoriesType;
 import com.synopsys.integration.blackduck.api.generated.view.ProjectVersionView;
 import com.synopsys.integration.blackduck.api.generated.view.TagView;
@@ -63,7 +65,7 @@ public class ProjectView extends BlackDuckView {
     private Boolean projectLevelAdjustments;
     private String projectOwner;
     private Integer projectTier;
-    private Boolean purgeUnmatchedFilesEnabled;
+    private Varies purgeUnmatchedFilesEnabled;
     private String repository;
     private String repositoryGroupId;
     private String repositoryName;
@@ -169,11 +171,11 @@ public class ProjectView extends BlackDuckView {
         this.projectTier = projectTier;
     }
 
-    public Boolean getPurgeUnmatchedFilesEnabled() {
+    public Varies getPurgeUnmatchedFilesEnabled() {
         return purgeUnmatchedFilesEnabled;
     }
 
-    public void setPurgeUnmatchedFilesEnabled(Boolean purgeUnmatchedFilesEnabled) {
+    public void setPurgeUnmatchedFilesEnabled(Varies purgeUnmatchedFilesEnabled) {
         this.purgeUnmatchedFilesEnabled = purgeUnmatchedFilesEnabled;
     }
 

--- a/src/main/java/com/synopsys/integration/blackduck/api/generated/view/SbomFieldsScopesView.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/generated/view/SbomFieldsScopesView.java
@@ -1,0 +1,34 @@
+/*
+ * blackduck-common-api
+ *
+ * Copyright (c) 2023 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
+package com.synopsys.integration.blackduck.api.generated.view;
+
+import com.synopsys.integration.blackduck.api.core.BlackDuckView;
+import com.synopsys.integration.blackduck.api.generated.enumeration.SbomFieldsScopesItemsScopeNameType;
+
+// this file should not be edited - if changes are necessary, the generator should be updated, then this file should be re-created
+public class SbomFieldsScopesView extends BlackDuckView {
+    private String name;
+    private SbomFieldsScopesItemsScopeNameType scopeName;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public SbomFieldsScopesItemsScopeNameType getScopeName() {
+        return scopeName;
+    }
+
+    public void setScopeName(SbomFieldsScopesItemsScopeNameType scopeName) {
+        this.scopeName = scopeName;
+    }
+
+}

--- a/src/main/java/com/synopsys/integration/blackduck/api/generated/view/ScanFullResultView.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/generated/view/ScanFullResultView.java
@@ -1,0 +1,218 @@
+/*
+ * blackduck-common-api
+ *
+ * Copyright (c) 2023 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
+package com.synopsys.integration.blackduck.api.generated.view;
+
+import java.math.BigDecimal;
+import com.synopsys.integration.blackduck.api.core.BlackDuckComponent;
+import com.synopsys.integration.blackduck.api.core.BlackDuckView;
+import com.synopsys.integration.blackduck.api.generated.component.ScanFullResultItemsAllLicensesView;
+import com.synopsys.integration.blackduck.api.generated.component.ScanFullResultItemsAllVulnerabilitiesView;
+import com.synopsys.integration.blackduck.api.generated.component.ScanFullResultItemsComponentViolatingPoliciesView;
+import com.synopsys.integration.blackduck.api.generated.component.ScanFullResultItemsFailedEvaluationPoliciesView;
+import com.synopsys.integration.blackduck.api.generated.component.ScanFullResultItemsLongTermUpgradeGuidanceView;
+import com.synopsys.integration.blackduck.api.generated.component.ScanFullResultItemsOverriddenPoliciesPartialView;
+import com.synopsys.integration.blackduck.api.generated.component.ScanFullResultItemsOverriddenPoliciesView;
+import com.synopsys.integration.blackduck.api.generated.component.ScanFullResultItemsPolicyViolationLicensesView;
+import com.synopsys.integration.blackduck.api.generated.component.ScanFullResultItemsPolicyViolationVulnerabilitiesView;
+import com.synopsys.integration.blackduck.api.generated.component.ScanFullResultItemsShortTermUpgradeGuidanceView;
+import com.synopsys.integration.blackduck.api.generated.component.ScanFullResultItemsTransitiveUpgradeGuidanceView;
+import com.synopsys.integration.blackduck.api.generated.component.ScanFullResultItemsViolatingPoliciesView;
+
+// this file should not be edited - if changes are necessary, the generator should be updated, then this file should be re-created
+public class ScanFullResultView extends BlackDuckView {
+    private java.util.List<ScanFullResultItemsAllLicensesView> allLicenses;
+    private java.util.List<ScanFullResultItemsAllVulnerabilitiesView> allVulnerabilities;
+    private String componentIdentifier;
+    private String componentName;
+    private java.util.List<ScanFullResultItemsComponentViolatingPoliciesView> componentViolatingPolicies;
+    private java.util.List<java.util.List<String>> dependencyTrees;
+    private String externalId;
+    private java.util.List<ScanFullResultItemsFailedEvaluationPoliciesView> failedEvaluationPolicies;
+    private String filePath;
+    private ScanFullResultItemsLongTermUpgradeGuidanceView longTermUpgradeGuidance;
+    private BigDecimal matchConfidence;
+    private java.util.List<String> nonEvaluatedPolicies;
+    private java.util.List<ScanFullResultItemsOverriddenPoliciesView> overriddenPolicies;
+    private java.util.List<ScanFullResultItemsOverriddenPoliciesPartialView> overriddenPoliciesPartial;
+    private java.util.List<String> partiallyEvaluatedPolicies;
+    private java.util.List<ScanFullResultItemsPolicyViolationLicensesView> policyViolationLicenses;
+    private java.util.List<ScanFullResultItemsPolicyViolationVulnerabilitiesView> policyViolationVulnerabilities;
+    private ScanFullResultItemsShortTermUpgradeGuidanceView shortTermUpgradeGuidance;
+    private java.util.List<ScanFullResultItemsTransitiveUpgradeGuidanceView> transitiveUpgradeGuidance;
+    private String versionName;
+    private java.util.List<ScanFullResultItemsViolatingPoliciesView> violatingPolicies;
+
+    public java.util.List<ScanFullResultItemsAllLicensesView> getAllLicenses() {
+        return allLicenses;
+    }
+
+    public void setAllLicenses(java.util.List<ScanFullResultItemsAllLicensesView> allLicenses) {
+        this.allLicenses = allLicenses;
+    }
+
+    public java.util.List<ScanFullResultItemsAllVulnerabilitiesView> getAllVulnerabilities() {
+        return allVulnerabilities;
+    }
+
+    public void setAllVulnerabilities(java.util.List<ScanFullResultItemsAllVulnerabilitiesView> allVulnerabilities) {
+        this.allVulnerabilities = allVulnerabilities;
+    }
+
+    public String getComponentIdentifier() {
+        return componentIdentifier;
+    }
+
+    public void setComponentIdentifier(String componentIdentifier) {
+        this.componentIdentifier = componentIdentifier;
+    }
+
+    public String getComponentName() {
+        return componentName;
+    }
+
+    public void setComponentName(String componentName) {
+        this.componentName = componentName;
+    }
+
+    public java.util.List<ScanFullResultItemsComponentViolatingPoliciesView> getComponentViolatingPolicies() {
+        return componentViolatingPolicies;
+    }
+
+    public void setComponentViolatingPolicies(java.util.List<ScanFullResultItemsComponentViolatingPoliciesView> componentViolatingPolicies) {
+        this.componentViolatingPolicies = componentViolatingPolicies;
+    }
+
+    public java.util.List<java.util.List<String>> getDependencyTrees() {
+        return dependencyTrees;
+    }
+
+    public void setDependencyTrees(java.util.List<java.util.List<String>> dependencyTrees) {
+        this.dependencyTrees = dependencyTrees;
+    }
+
+    public String getExternalId() {
+        return externalId;
+    }
+
+    public void setExternalId(String externalId) {
+        this.externalId = externalId;
+    }
+
+    public java.util.List<ScanFullResultItemsFailedEvaluationPoliciesView> getFailedEvaluationPolicies() {
+        return failedEvaluationPolicies;
+    }
+
+    public void setFailedEvaluationPolicies(java.util.List<ScanFullResultItemsFailedEvaluationPoliciesView> failedEvaluationPolicies) {
+        this.failedEvaluationPolicies = failedEvaluationPolicies;
+    }
+
+    public String getFilePath() {
+        return filePath;
+    }
+
+    public void setFilePath(String filePath) {
+        this.filePath = filePath;
+    }
+
+    public ScanFullResultItemsLongTermUpgradeGuidanceView getLongTermUpgradeGuidance() {
+        return longTermUpgradeGuidance;
+    }
+
+    public void setLongTermUpgradeGuidance(ScanFullResultItemsLongTermUpgradeGuidanceView longTermUpgradeGuidance) {
+        this.longTermUpgradeGuidance = longTermUpgradeGuidance;
+    }
+
+    public BigDecimal getMatchConfidence() {
+        return matchConfidence;
+    }
+
+    public void setMatchConfidence(BigDecimal matchConfidence) {
+        this.matchConfidence = matchConfidence;
+    }
+
+    public java.util.List<String> getNonEvaluatedPolicies() {
+        return nonEvaluatedPolicies;
+    }
+
+    public void setNonEvaluatedPolicies(java.util.List<String> nonEvaluatedPolicies) {
+        this.nonEvaluatedPolicies = nonEvaluatedPolicies;
+    }
+
+    public java.util.List<ScanFullResultItemsOverriddenPoliciesView> getOverriddenPolicies() {
+        return overriddenPolicies;
+    }
+
+    public void setOverriddenPolicies(java.util.List<ScanFullResultItemsOverriddenPoliciesView> overriddenPolicies) {
+        this.overriddenPolicies = overriddenPolicies;
+    }
+
+    public java.util.List<ScanFullResultItemsOverriddenPoliciesPartialView> getOverriddenPoliciesPartial() {
+        return overriddenPoliciesPartial;
+    }
+
+    public void setOverriddenPoliciesPartial(java.util.List<ScanFullResultItemsOverriddenPoliciesPartialView> overriddenPoliciesPartial) {
+        this.overriddenPoliciesPartial = overriddenPoliciesPartial;
+    }
+
+    public java.util.List<String> getPartiallyEvaluatedPolicies() {
+        return partiallyEvaluatedPolicies;
+    }
+
+    public void setPartiallyEvaluatedPolicies(java.util.List<String> partiallyEvaluatedPolicies) {
+        this.partiallyEvaluatedPolicies = partiallyEvaluatedPolicies;
+    }
+
+    public java.util.List<ScanFullResultItemsPolicyViolationLicensesView> getPolicyViolationLicenses() {
+        return policyViolationLicenses;
+    }
+
+    public void setPolicyViolationLicenses(java.util.List<ScanFullResultItemsPolicyViolationLicensesView> policyViolationLicenses) {
+        this.policyViolationLicenses = policyViolationLicenses;
+    }
+
+    public java.util.List<ScanFullResultItemsPolicyViolationVulnerabilitiesView> getPolicyViolationVulnerabilities() {
+        return policyViolationVulnerabilities;
+    }
+
+    public void setPolicyViolationVulnerabilities(java.util.List<ScanFullResultItemsPolicyViolationVulnerabilitiesView> policyViolationVulnerabilities) {
+        this.policyViolationVulnerabilities = policyViolationVulnerabilities;
+    }
+
+    public ScanFullResultItemsShortTermUpgradeGuidanceView getShortTermUpgradeGuidance() {
+        return shortTermUpgradeGuidance;
+    }
+
+    public void setShortTermUpgradeGuidance(ScanFullResultItemsShortTermUpgradeGuidanceView shortTermUpgradeGuidance) {
+        this.shortTermUpgradeGuidance = shortTermUpgradeGuidance;
+    }
+
+    public java.util.List<ScanFullResultItemsTransitiveUpgradeGuidanceView> getTransitiveUpgradeGuidance() {
+        return transitiveUpgradeGuidance;
+    }
+
+    public void setTransitiveUpgradeGuidance(java.util.List<ScanFullResultItemsTransitiveUpgradeGuidanceView> transitiveUpgradeGuidance) {
+        this.transitiveUpgradeGuidance = transitiveUpgradeGuidance;
+    }
+
+    public String getVersionName() {
+        return versionName;
+    }
+
+    public void setVersionName(String versionName) {
+        this.versionName = versionName;
+    }
+
+    public java.util.List<ScanFullResultItemsViolatingPoliciesView> getViolatingPolicies() {
+        return violatingPolicies;
+    }
+
+    public void setViolatingPolicies(java.util.List<ScanFullResultItemsViolatingPoliciesView> violatingPolicies) {
+        this.violatingPolicies = violatingPolicies;
+    }
+
+}

--- a/src/main/java/com/synopsys/integration/blackduck/api/generated/view/ScanMonitorView.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/generated/view/ScanMonitorView.java
@@ -1,0 +1,34 @@
+/*
+ * blackduck-common-api
+ *
+ * Copyright (c) 2023 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
+package com.synopsys.integration.blackduck.api.generated.view;
+
+import java.math.BigDecimal;
+import com.synopsys.integration.blackduck.api.core.BlackDuckView;
+
+// this file should not be edited - if changes are necessary, the generator should be updated, then this file should be re-created
+public class ScanMonitorView extends BlackDuckView {
+    private BigDecimal level;
+    private String scanHealth;
+
+    public BigDecimal getLevel() {
+        return level;
+    }
+
+    public void setLevel(BigDecimal level) {
+        this.level = level;
+    }
+
+    public String getScanHealth() {
+        return scanHealth;
+    }
+
+    public void setScanHealth(String scanHealth) {
+        this.scanHealth = scanHealth;
+    }
+
+}

--- a/src/main/java/com/synopsys/integration/blackduck/api/generated/view/ScanView.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/generated/view/ScanView.java
@@ -25,6 +25,7 @@ public class ScanView extends BlackDuckView {
     private BigDecimal fileCount;
     private String hostName;
     private BigDecimal matchCount;
+    private Boolean retainUnmatchedFiles;
     private BigDecimal scanSize;
     private ScanStateType scanState;
     private ScanType scanType;
@@ -95,6 +96,14 @@ public class ScanView extends BlackDuckView {
 
     public void setMatchCount(BigDecimal matchCount) {
         this.matchCount = matchCount;
+    }
+
+    public Boolean getRetainUnmatchedFiles() {
+        return retainUnmatchedFiles;
+    }
+
+    public void setRetainUnmatchedFiles(Boolean retainUnmatchedFiles) {
+        this.retainUnmatchedFiles = retainUnmatchedFiles;
     }
 
     public BigDecimal getScanSize() {

--- a/src/main/java/com/synopsys/integration/blackduck/api/generated/view/ToolsView.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/generated/view/ToolsView.java
@@ -1,0 +1,88 @@
+/*
+ * blackduck-common-api
+ *
+ * Copyright (c) 2023 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
+package com.synopsys.integration.blackduck.api.generated.view;
+
+import java.math.BigDecimal;
+import com.synopsys.integration.blackduck.api.core.BlackDuckView;
+
+// this file should not be edited - if changes are necessary, the generator should be updated, then this file should be re-created
+public class ToolsView extends BlackDuckView {
+    private BigDecimal accessCount;
+    private String lastAccessed;
+    private String lastModified;
+    private String name;
+    private String platform;
+    private String provider;
+    private BigDecimal size;
+    private String version;
+
+    public BigDecimal getAccessCount() {
+        return accessCount;
+    }
+
+    public void setAccessCount(BigDecimal accessCount) {
+        this.accessCount = accessCount;
+    }
+
+    public String getLastAccessed() {
+        return lastAccessed;
+    }
+
+    public void setLastAccessed(String lastAccessed) {
+        this.lastAccessed = lastAccessed;
+    }
+
+    public String getLastModified() {
+        return lastModified;
+    }
+
+    public void setLastModified(String lastModified) {
+        this.lastModified = lastModified;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getPlatform() {
+        return platform;
+    }
+
+    public void setPlatform(String platform) {
+        this.platform = platform;
+    }
+
+    public String getProvider() {
+        return provider;
+    }
+
+    public void setProvider(String provider) {
+        this.provider = provider;
+    }
+
+    public BigDecimal getSize() {
+        return size;
+    }
+
+    public void setSize(BigDecimal size) {
+        this.size = size;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+}


### PR DESCRIPTION
Pull request for new "full-result" api objects.  This has been "locally tested" and successfully gets the transitive guidance.  It's pretty much all generated code.  Some of the objects have nothing to do with this issue (eg. Bom classes) however they may be needed in upcoming releases.

The classes that DO impact this ticket, are the ScanFullResult.... ones.

This PR must be completed (along with subsequent library version updates) before the synopsys-detect changes can be merged.
