### PR TITLE
2023.4.2 generation with bom status scanId tweak

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
 project.ext.moduleName = 'com.synopsys.integration.blackduck-common-api'
 project.ext.javaUseAutoModuleName = 'true'
 
-version = '2023.4.0.2-SNAPSHOT'
+version = '2023.4.2.1-SNAPSHOT'
 
 description = 'A library of mostly temporary request/response classes for the Black Duck REST API.'
 

--- a/src/main/java/com/synopsys/integration/blackduck/api/generated/component/CanGenerateSbomReportView.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/generated/component/CanGenerateSbomReportView.java
@@ -1,0 +1,24 @@
+/*
+ * blackduck-common-api
+ *
+ * Copyright (c) 2023 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
+package com.synopsys.integration.blackduck.api.generated.component;
+
+import com.synopsys.integration.blackduck.api.core.BlackDuckComponent;
+
+// this file should not be edited - if changes are necessary, the generator should be updated, then this file should be re-created
+public class CanGenerateSbomReportView extends BlackDuckComponent {
+    private Boolean canGenerateSBOMReport;
+
+    public Boolean getCanGenerateSBOMReport() {
+        return canGenerateSBOMReport;
+    }
+
+    public void setCanGenerateSBOMReport(Boolean canGenerateSBOMReport) {
+        this.canGenerateSBOMReport = canGenerateSBOMReport;
+    }
+
+}

--- a/src/main/java/com/synopsys/integration/blackduck/api/generated/component/ProjectGroupReportSettingsView.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/generated/component/ProjectGroupReportSettingsView.java
@@ -1,0 +1,33 @@
+/*
+ * blackduck-common-api
+ *
+ * Copyright (c) 2023 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
+package com.synopsys.integration.blackduck.api.generated.component;
+
+import com.synopsys.integration.blackduck.api.core.BlackDuckComponent;
+
+// this file should not be edited - if changes are necessary, the generator should be updated, then this file should be re-created
+public class ProjectGroupReportSettingsView extends BlackDuckComponent {
+    private Boolean blockSbomReportGenerationWithPolicyViolations;
+    private Boolean propagation;
+
+    public Boolean getBlockSbomReportGenerationWithPolicyViolations() {
+        return blockSbomReportGenerationWithPolicyViolations;
+    }
+
+    public void setBlockSbomReportGenerationWithPolicyViolations(Boolean blockSbomReportGenerationWithPolicyViolations) {
+        this.blockSbomReportGenerationWithPolicyViolations = blockSbomReportGenerationWithPolicyViolations;
+    }
+
+    public Boolean getPropagation() {
+        return propagation;
+    }
+
+    public void setPropagation(Boolean propagation) {
+        this.propagation = propagation;
+    }
+
+}

--- a/src/main/java/com/synopsys/integration/blackduck/api/generated/component/ProjectSbomFieldsView.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/generated/component/ProjectSbomFieldsView.java
@@ -1,0 +1,42 @@
+/*
+ * blackduck-common-api
+ *
+ * Copyright (c) 2023 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
+package com.synopsys.integration.blackduck.api.generated.component;
+
+import com.synopsys.integration.blackduck.api.core.BlackDuckComponent;
+
+// this file should not be edited - if changes are necessary, the generator should be updated, then this file should be re-created
+public class ProjectSbomFieldsView extends BlackDuckComponent {
+    private String fieldName;
+    private String label;
+    private String value;
+
+    public String getFieldName() {
+        return fieldName;
+    }
+
+    public void setFieldName(String fieldName) {
+        this.fieldName = fieldName;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public void setLabel(String label) {
+        this.label = label;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+}

--- a/src/main/java/com/synopsys/integration/blackduck/api/generated/component/SettingsDetectView.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/generated/component/SettingsDetectView.java
@@ -14,6 +14,7 @@ public class SettingsDetectView extends BlackDuckComponent {
     private java.util.List<String> allVersions;
     private Boolean allowDowngrade;
     private String detectUri;
+    private String errorMessage;
     private java.util.List<String> majorVersions;
     private String selectedVersion;
     private Boolean useInternalHosting;
@@ -41,6 +42,14 @@ public class SettingsDetectView extends BlackDuckComponent {
 
     public void setDetectUri(String detectUri) {
         this.detectUri = detectUri;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public void setErrorMessage(String errorMessage) {
+        this.errorMessage = errorMessage;
     }
 
     public java.util.List<String> getMajorVersions() {

--- a/src/main/java/com/synopsys/integration/blackduck/api/generated/discovery/BlackDuckMediaTypeDiscovery.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/generated/discovery/BlackDuckMediaTypeDiscovery.java
@@ -141,6 +141,7 @@ public class BlackDuckMediaTypeDiscovery {
     public static final String API_PROJECT_GROUPS_HIERARCHY = String.format("/api/project-groups/%s/hierarchy", UUID_REGEX);
     public static final String API_PROJECT_GROUPS_POSSIBLE_CHILD_PROJECT_GROUPS = String.format("/api/project-groups/%s/possible-child-project-groups", UUID_REGEX);
     public static final String API_PROJECT_GROUPS_PROJECT_GROUPS = String.format("/api/project-groups/%s/project-groups", UUID_REGEX);
+    public static final String API_PROJECT_GROUPS_REPORT_SETTINGS = String.format("/api/project-groups/%s/report-settings", UUID_REGEX);
     public static final String API_PROJECT_GROUPS_SBOM_FIELDS = String.format("/api/project-groups/%s/sbom-fields", UUID_REGEX);
     public static final String API_PROJECT_GROUPS_USERGROUPS_WITH_ID = String.format("/api/project-groups/%s/usergroups/%s", UUID_REGEX, UUID_REGEX);
     public static final String API_PROJECT_GROUPS_USERS_WITH_ID = String.format("/api/project-groups/%s/users/%s", UUID_REGEX, UUID_REGEX);
@@ -148,6 +149,7 @@ public class BlackDuckMediaTypeDiscovery {
     public static final String API_PROJECTS_WITH_ID = String.format("/api/projects/%s", UUID_REGEX);
     public static final String API_PROJECTS_CUSTOM_FIELDS_WITH_ID = String.format("/api/projects/%s/custom-fields/%s", UUID_REGEX, UUID_REGEX);
     public static final String API_PROJECTS_PROJECT_MAPPINGS_WITH_ID = String.format("/api/projects/%s/project-mappings/%s", UUID_REGEX, UUID_REGEX);
+    public static final String API_PROJECTS_SBOM_FIELDS = String.format("/api/projects/%s/sbom-fields", UUID_REGEX);
     public static final String API_PROJECTS_SCM = String.format("/api/projects/%s/scm", UUID_REGEX);
     public static final String API_PROJECTS_TAGS_WITH_ID = String.format("/api/projects/%s/tags/%s", UUID_REGEX, UUID_REGEX);
     public static final String API_PROJECTS_USERGROUPS_WITH_ID = String.format("/api/projects/%s/usergroups/%s", UUID_REGEX, UUID_REGEX);
@@ -155,6 +157,7 @@ public class BlackDuckMediaTypeDiscovery {
     public static final String API_PROJECTS_VERSIONS_WITH_ID = String.format("/api/projects/%s/versions/%s", UUID_REGEX, UUID_REGEX);
     public static final String API_PROJECTS_VERSIONS_BOM_EVENTS = String.format("/api/projects/%s/versions/%s/bom-events", UUID_REGEX, UUID_REGEX);
     public static final String API_PROJECTS_VERSIONS_BOM_STATUS = String.format("/api/projects/%s/versions/%s/bom-status", UUID_REGEX, UUID_REGEX);
+    public static final String API_PROJECTS_VERSIONS_BOM_STATUS_WITH_ID = String.format("/api/projects/%s/versions/%s/bom-status/%s", UUID_REGEX, UUID_REGEX, UUID_REGEX);
     public static final String API_PROJECTS_VERSIONS_CODE_LOCATIONS = String.format("/api/projects/%s/versions/%s/code-locations", UUID_REGEX, UUID_REGEX);
     public static final String API_PROJECTS_VERSIONS_COMPARISON = String.format("/api/projects/%s/versions/%s/comparison", UUID_REGEX, UUID_REGEX);
     public static final String API_PROJECTS_VERSIONS_COMPONENTS_WITH_ID = String.format("/api/projects/%s/versions/%s/components/%s", UUID_REGEX, UUID_REGEX, UUID_REGEX);
@@ -186,6 +189,7 @@ public class BlackDuckMediaTypeDiscovery {
     public static final String API_PROJECTS_VERSIONS_POLICY_STATUS = String.format("/api/projects/%s/versions/%s/policy-status", UUID_REGEX, UUID_REGEX);
     public static final String API_PROJECTS_VERSIONS_REPORTS_WITH_ID = String.format("/api/projects/%s/versions/%s/reports/%s", UUID_REGEX, UUID_REGEX, UUID_REGEX);
     public static final String API_PROJECTS_VERSIONS_REPORTS_CONTENTS = String.format("/api/projects/%s/versions/%s/reports/%s/contents", UUID_REGEX, UUID_REGEX, UUID_REGEX);
+    public static final String API_PROJECTS_VERSIONS_REPORTS_CAN_GENERATE_SBOM_REPORT = String.format("/api/projects/%s/versions/%s/reports/can-generate-sbom-report", UUID_REGEX, UUID_REGEX);
     public static final String API_PROJECTS_VERSIONS_SOURCE_VIEW_COMMENTS_WITH_ID = String.format("/api/projects/%s/versions/%s/source-view/%s/comments/%s", UUID_REGEX, UUID_REGEX, UUID_REGEX, UUID_REGEX);
     public static final String API_PROJECTS_VERSIONS_VULNERABILITIES_VULNERABILITY_MATCHES = String.format("/api/projects/%s/versions/%s/vulnerabilities/%s/vulnerability-matches", UUID_REGEX, UUID_REGEX, UUID_REGEX);
     public static final String API_PROJECTS_VERSIONS_VULNERABLE_BOM_COMPONENTS = String.format("/api/projects/%s/versions/%s/vulnerable-bom-components", UUID_REGEX, UUID_REGEX);
@@ -333,12 +337,14 @@ public class BlackDuckMediaTypeDiscovery {
         mediaTypeMatchers.add(new MediaTypeMatcher(API_POLICY_RULES_WITH_ID, VND_BLACKDUCKSOFTWARE_POLICY_5_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECTS_CUSTOM_FIELDS_WITH_ID, VND_BLACKDUCKSOFTWARE_PROJECT_DETAIL_5_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECTS_PROJECT_MAPPINGS_WITH_ID, VND_BLACKDUCKSOFTWARE_PROJECT_DETAIL_4_JSON));
+        mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECTS_SBOM_FIELDS, VND_BLACKDUCKSOFTWARE_PROJECT_DETAIL_6_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECTS_SCM, VND_BLACKDUCKSOFTWARE_PROJECT_DETAIL_5_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECTS_TAGS_WITH_ID, VND_BLACKDUCKSOFTWARE_PROJECT_DETAIL_5_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECTS_USERGROUPS_WITH_ID, VND_BLACKDUCKSOFTWARE_PROJECT_DETAIL_4_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECTS_USERS_WITH_ID, VND_BLACKDUCKSOFTWARE_PROJECT_DETAIL_4_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECTS_VERSIONS_BOM_EVENTS, VND_BLACKDUCKSOFTWARE_BILL_OF_MATERIALS_6_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECTS_VERSIONS_BOM_STATUS, VND_BLACKDUCKSOFTWARE_BILL_OF_MATERIALS_6_JSON));
+        mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECTS_VERSIONS_BOM_STATUS_WITH_ID, VND_BLACKDUCKSOFTWARE_BILL_OF_MATERIALS_6_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECTS_VERSIONS_CODE_LOCATIONS, VND_BLACKDUCKSOFTWARE_INTERNAL_1_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECTS_VERSIONS_COMPARISON, VND_BLACKDUCKSOFTWARE_BILL_OF_MATERIALS_6_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECTS_VERSIONS_COMPONENTS_COMMENTS_WITH_ID, VND_BLACKDUCKSOFTWARE_BILL_OF_MATERIALS_6_JSON));
@@ -368,6 +374,7 @@ public class BlackDuckMediaTypeDiscovery {
         mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECTS_VERSIONS_MATCHED_FILES, VND_BLACKDUCKSOFTWARE_BILL_OF_MATERIALS_6_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECTS_VERSIONS_POLICY_RULES, VND_BLACKDUCKSOFTWARE_BILL_OF_MATERIALS_6_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECTS_VERSIONS_POLICY_STATUS, VND_BLACKDUCKSOFTWARE_BILL_OF_MATERIALS_6_JSON));
+        mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECTS_VERSIONS_REPORTS_CAN_GENERATE_SBOM_REPORT, VND_BLACKDUCKSOFTWARE_REPORT_4_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECTS_VERSIONS_REPORTS_CONTENTS, VND_BLACKDUCKSOFTWARE_REPORT_4_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECTS_VERSIONS_REPORTS_WITH_ID, VND_BLACKDUCKSOFTWARE_REPORT_4_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECTS_VERSIONS_SOURCE_VIEW_COMMENTS_WITH_ID, VND_BLACKDUCKSOFTWARE_SOURCE_VIEW_1_JSON));
@@ -382,6 +389,7 @@ public class BlackDuckMediaTypeDiscovery {
         mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECT_GROUPS_HIERARCHY, VND_BLACKDUCKSOFTWARE_PROJECT_DETAIL_5_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECT_GROUPS_POSSIBLE_CHILD_PROJECT_GROUPS, VND_BLACKDUCKSOFTWARE_PROJECT_DETAIL_5_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECT_GROUPS_PROJECT_GROUPS, VND_BLACKDUCKSOFTWARE_PROJECT_DETAIL_5_JSON));
+        mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECT_GROUPS_REPORT_SETTINGS, VND_BLACKDUCKSOFTWARE_PROJECT_DETAIL_5_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECT_GROUPS_SBOM_FIELDS, VND_BLACKDUCKSOFTWARE_PROJECT_DETAIL_5_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECT_GROUPS_USERGROUPS_WITH_ID, VND_BLACKDUCKSOFTWARE_PROJECT_DETAIL_5_JSON));
         mediaTypeMatchers.add(new MediaTypeMatcher(API_PROJECT_GROUPS_USERS_WITH_ID, VND_BLACKDUCKSOFTWARE_PROJECT_DETAIL_5_JSON));

--- a/src/main/java/com/synopsys/integration/blackduck/api/generated/enumeration/BomStatusScanStatusType.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/generated/enumeration/BomStatusScanStatusType.java
@@ -10,11 +10,11 @@ package com.synopsys.integration.blackduck.api.generated.enumeration;
 import com.synopsys.integration.util.EnumUtils;
 
 // this file should not be edited - if changes are necessary, the generator should be updated, then this file should be re-created
-public enum SbomFieldsScopesItemsScopeNameType {
-    bom_component,
-	component,
-	project,
-	project_group;
+public enum BomStatusScanStatusType {
+    BUILDING,
+	FAILURE,
+	NOT_INCLUDED,
+	SUCCESS;
 
     public String prettyPrint() {
         return EnumUtils.prettyPrint(this);

--- a/src/main/java/com/synopsys/integration/blackduck/api/generated/enumeration/ComponentVersionSbomFieldsItemsValueType.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/generated/enumeration/ComponentVersionSbomFieldsItemsValueType.java
@@ -11,7 +11,7 @@ import com.synopsys.integration.util.EnumUtils;
 
 // this file should not be edited - if changes are necessary, the generator should be updated, then this file should be re-created
 public enum ComponentVersionSbomFieldsItemsValueType {
-    organization,
+	organization,
 	person;
 
     public String prettyPrint() {

--- a/src/main/java/com/synopsys/integration/blackduck/api/generated/view/BomStatusScanView.java
+++ b/src/main/java/com/synopsys/integration/blackduck/api/generated/view/BomStatusScanView.java
@@ -1,0 +1,25 @@
+/*
+ * blackduck-common-api
+ *
+ * Copyright (c) 2023 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
+package com.synopsys.integration.blackduck.api.generated.view;
+
+import com.synopsys.integration.blackduck.api.core.BlackDuckView;
+import com.synopsys.integration.blackduck.api.generated.enumeration.BomStatusScanStatusType;
+
+// this file should not be edited - if changes are necessary, the generator should be updated, then this file should be re-created
+public class BomStatusScanView extends BlackDuckView {
+    private BomStatusScanStatusType status;
+
+    public BomStatusScanStatusType getStatus() {
+        return status;
+    }
+
+    public void setStatus(BomStatusScanStatusType status) {
+        this.status = status;
+    }
+
+}


### PR DESCRIPTION
master is currently broken for Detect usage as the previous 2023.4 generation was missing the bom-status/{scanId} endpoint. This caused two classes Detect depends on to be deleted.

This MR generates off the 2023.4.2 specification with a manually updated bom-status/{scanId} section stolen from 2022.10 where this last worked. It is hoped that HUB-39253 will address this. 