### PR TITLE
add deep license project fields

### DIFF
--- a/src/main/java/com/blackduck/integration/blackduck/api/manual/temporary/component/ProjectRequest.java
+++ b/src/main/java/com/blackduck/integration/blackduck/api/manual/temporary/component/ProjectRequest.java
@@ -14,6 +14,8 @@ import com.blackduck.integration.blackduck.api.generated.enumeration.ProjectClon
 public class ProjectRequest extends BlackDuckComponent {
     private java.util.List<ProjectCloneCategoriesType> cloneCategories;
     private Boolean customSignatureEnabled;
+    private Boolean deepLicenseDataEnabled;
+    private Boolean deepLicenseDataSnippetEnabled;    
     private String description;
     private String name;
     private Boolean projectLevelAdjustments;
@@ -36,6 +38,22 @@ public class ProjectRequest extends BlackDuckComponent {
 
     public void setCustomSignatureEnabled(Boolean customSignatureEnabled) {
         this.customSignatureEnabled = customSignatureEnabled;
+    }
+    
+    public Boolean getDeepLicenseDataEnabled() {
+        return deepLicenseDataEnabled;
+    }
+
+    public void setDeepLicenseDataEnabled(Boolean deepLicenseDataEnabled) {
+        this.deepLicenseDataEnabled = deepLicenseDataEnabled;
+    }
+    
+    public Boolean getDeepLicenseDataSnippetEnabled() {
+        return deepLicenseDataSnippetEnabled;
+    }
+
+    public void setDeepLicenseDataSnippetEnabled(Boolean deepLicenseDataSnippetEnabled) {
+        this.deepLicenseDataSnippetEnabled = deepLicenseDataSnippetEnabled;
     }
 
     public String getDescription() {

--- a/src/main/java/com/blackduck/integration/blackduck/api/manual/view/ProjectView.java
+++ b/src/main/java/com/blackduck/integration/blackduck/api/manual/view/ProjectView.java
@@ -58,6 +58,8 @@ public class ProjectView extends BlackDuckView {
     private String createdByUser;
     private BigDecimal customSignatureDepth;
     private Boolean customSignatureEnabled;
+    private Boolean deepLicenseDataEnabled;
+    private Boolean deepLicenseDataSnippetEnabled;
     private String description;
     private String name;
     private String projectGroup;
@@ -120,6 +122,22 @@ public class ProjectView extends BlackDuckView {
 
     public void setCustomSignatureEnabled(Boolean customSignatureEnabled) {
         this.customSignatureEnabled = customSignatureEnabled;
+    }
+    
+    public Boolean getDeepLicenseDataEnabled() {
+        return deepLicenseDataEnabled;
+    }
+
+    public void setDeepLicenseDataEnabledEnabled(Boolean deepLicenseDataEnabled) {
+        this.deepLicenseDataEnabled = deepLicenseDataEnabled;
+    }
+    
+    public Boolean getDeepLicenseDataSnippetEnabled() {
+        return deepLicenseDataSnippetEnabled;
+    }
+
+    public void setDeepLicenseDataSnippetEnabled(Boolean deepLicenseDataSnippetEnabled) {
+        this.deepLicenseDataSnippetEnabled = deepLicenseDataSnippetEnabled;
     }
 
     public String getDescription() {


### PR DESCRIPTION
This PR adds two new fields that can be used when creating and updating BlackDuck projects. It's very similar to customSignatureEnabled and that property was used as a model in making the alterations. This will later be used by blackduck-common.