### PR TITLE
remove archived value

### DIFF
--- a/src/main/java/com/blackduck/integration/blackduck/api/manual/temporary/enumeration/ProjectVersionPhaseType.java
+++ b/src/main/java/com/blackduck/integration/blackduck/api/manual/temporary/enumeration/ProjectVersionPhaseType.java
@@ -11,7 +11,6 @@ import com.blackduck.integration.util.EnumUtils;
 
 //this file should not be edited - if changes are necessary, the generator should be updated, then this file should be re-created
 public enum ProjectVersionPhaseType {
-    ARCHIVED,
     DEPRECATED,
     DEVELOPMENT,
     PLANNING,


### PR DESCRIPTION
Black Duck will no longer be supporting this value. Detect has deprecated it since 11.0 and it will be removed in 11.2.

Note: the generator message can be ignored as I'm doing this in the manual package as an override.