### PR TITLE
Update integration-rest for EU CRA fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,5 +20,5 @@ description = 'A library of mostly temporary request/response classes for the Bl
 apply plugin: 'com.blackduck.integration.library'
 
 dependencies {
-    api 'com.blackduck.integration:integration-rest:11.1.3'
+    api 'com.blackduck.integration:integration-rest:11.1.4'
 }


### PR DESCRIPTION
**JIRA Ticket**

IDETECT-5081

**Description**

 This pull request bumps `integration-rest` version to the latest release `11.1.4`. The `integration-rest:11.1.4`  brings the latest release of `integration-common:27.0.4`  which updates  the direct dependency  `json-path` from `2.9.0` to `2.10.0` to resolve a transitive vulnerable dependency as part of the EU CRA compliance effort.
 
`json-path:2.9.0` pulls in `json-smart:2.5.0`, which carries **CVE-2024-57699 (BDSA-2025-0966)**. 
This update transitively brings in `json-smart:2.6.0`, which is free of this vulnerability, and thus the safe version flows to all downstream consumers automatically.